### PR TITLE
广州地铁8号线修正

### DIFF
--- a/public/resources/templates/gzmtr/gz8.json
+++ b/public/resources/templates/gzmtr/gz8.json
@@ -10,8 +10,8 @@
         "#fff"
     ],
     "direction": "l",
-    "current_stn_idx": "6t9l",
-    "platform_num": "1",
+    "current_stn_idx": "iwf6",
+    "platform_num": "3",
     "stn_list": {
         "linestart": {
             "parents": [],
@@ -736,10 +736,7 @@
                 "local"
             ],
             "facility": "",
-            "secondaryName": [
-                "未开通",
-                "Under Construction"
-            ],
+            "secondaryName": false,
             "loop_pivot": false,
             "one_line": false,
             "int_padding": 355


### PR DESCRIPTION
Hi, I'm the rmg bot updating 广州地铁8号线修正 on behalf of s1s1s1s1s1s.
This should fix #84

**Review links**
[gzmtr/gz8.json](https://uat-railmapgen.github.io/rmg/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F0ed230dc09837f0f1491fe071f566d6ebb4c33db%2Fpublic%2Fresources%2Ftemplates%2Fgzmtr%2Fgz8.json)