### PR TITLE
Resources: New templates of Seoul Metropolitan Subway（3）

### DIFF
--- a/public/resources/templates/seoulmetro/00config.json
+++ b/public/resources/templates/seoulmetro/00config.json
@@ -144,7 +144,6 @@
         "uploadBy": "WOLFRAZOR"
     },
     {
-    
         "filename": "AREX",
         "name": {
             "en": "Incheon Airport Railroad Express",

--- a/public/resources/templates/seoulmetro/l5.json
+++ b/public/resources/templates/seoulmetro/l5.json
@@ -36,15 +36,11 @@
             ],
             "parents": [],
             "children": [
-                "nLftlv",
                 "7dYQDy"
             ],
             "branch": {
                 "left": [],
-                "right": [
-                    "through",
-                    "nLftlv"
-                ]
+                "right": []
             },
             "transfer": {
                 "info": [
@@ -136,11 +132,15 @@
                 "local"
             ],
             "parents": [
+                "dNLgaF",
                 "CTRuE1"
             ],
             "children": [],
             "branch": {
-                "left": [],
+                "left": [
+                    "through",
+                    "dNLgaF"
+                ],
                 "right": []
             },
             "transfer": {
@@ -497,18 +497,18 @@
                 "local"
             ],
             "parents": [
-                "-V9xif",
                 "jP-dgh"
             ],
             "children": [
+                "8NsAHF",
                 "KC5ruq"
             ],
             "branch": {
-                "left": [
+                "left": [],
+                "right": [
                     "through",
-                    "-V9xif"
-                ],
-                "right": []
+                    "8NsAHF"
+                ]
             },
             "transfer": {
                 "info": [
@@ -1902,21 +1902,21 @@
             "one_line": true,
             "int_padding": 355
         },
-        "nLftlv": {
+        "0ng-Yl": {
             "name": [
-                "马川",
-                "마천 \\Macheon"
+                "巨余",
+                "거여 \\Geoyeo"
             ],
             "secondaryName": false,
-            "num": "P55",
+            "num": "P54",
             "services": [
                 "local"
             ],
             "parents": [
-                "linestart"
+                "LitaYG"
             ],
             "children": [
-                "pEv2Tu"
+                "dNLgaF"
             ],
             "branch": {
                 "left": [],
@@ -1935,7 +1935,7 @@
             "one_line": true,
             "int_padding": 355
         },
-        "-V9xif": {
+        "8NsAHF": {
             "name": [
                 "遁村洞",
                 "둔촌동 \\Dunchon-dong"
@@ -1946,10 +1946,10 @@
                 "local"
             ],
             "parents": [
-                "iTtz3B"
+                "6Lf3bt"
             ],
             "children": [
-                "6Lf3bt"
+                "Ox2Rz0"
             ],
             "branch": {
                 "left": [],
@@ -1968,9 +1968,9 @@
             "one_line": true,
             "int_padding": 355
         },
-        "iTtz3B": {
+        "Ox2Rz0": {
             "name": [
-                "奥林匹克公园 ",
+                "奥林匹克公园 （韩国体育大学）",
                 "올림픽공원 （한국체대） \\Olympic Park （Korean National Sports Univ.）"
             ],
             "secondaryName": false,
@@ -1979,10 +1979,10 @@
                 "local"
             ],
             "parents": [
-                "KxcoHy"
+                "8NsAHF"
             ],
             "children": [
-                "-V9xif"
+                "WwXX0z"
             ],
             "branch": {
                 "left": [],
@@ -2010,7 +2010,7 @@
             "one_line": true,
             "int_padding": 355
         },
-        "KxcoHy": {
+        "WwXX0z": {
             "name": [
                 "芳荑",
                 "방이 \\Bangi"
@@ -2021,10 +2021,10 @@
                 "local"
             ],
             "parents": [
-                "UUQMFP"
+                "Ox2Rz0"
             ],
             "children": [
-                "iTtz3B"
+                "kh_Zy4"
             ],
             "branch": {
                 "left": [],
@@ -2043,7 +2043,7 @@
             "one_line": true,
             "int_padding": 355
         },
-        "UUQMFP": {
+        "kh_Zy4": {
             "name": [
                 "梧琴",
                 "오금 \\Ogeum"
@@ -2054,10 +2054,10 @@
                 "local"
             ],
             "parents": [
-                "f4CDaU"
+                "WwXX0z"
             ],
             "children": [
-                "KxcoHy"
+                "LitaYG"
             ],
             "branch": {
                 "left": [],
@@ -2085,10 +2085,10 @@
             "one_line": true,
             "int_padding": 355
         },
-        "f4CDaU": {
+        "LitaYG": {
             "name": [
                 "开笼",
-                "개롱  \\Gaerong"
+                "개롱 \\Gaerong"
             ],
             "secondaryName": false,
             "num": "P53",
@@ -2096,10 +2096,10 @@
                 "local"
             ],
             "parents": [
-                "pEv2Tu"
+                "kh_Zy4"
             ],
             "children": [
-                "UUQMFP"
+                "0ng-Yl"
             ],
             "branch": {
                 "left": [],
@@ -2118,21 +2118,21 @@
             "one_line": true,
             "int_padding": 355
         },
-        "pEv2Tu": {
+        "dNLgaF": {
             "name": [
-                "巨余",
-                "거여 \\Geoyeo"
+                "马川",
+                "마천 \\Macheon"
             ],
             "secondaryName": false,
-            "num": "P54",
+            "num": "P55",
             "services": [
                 "local"
             ],
             "parents": [
-                "nLftlv"
+                "0ng-Yl"
             ],
             "children": [
-                "f4CDaU"
+                "lineend"
             ],
             "branch": {
                 "left": [],


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Seoul Metropolitan Subway（3） on behalf of WOLFRAZOR.
This should fix #166

**Review links**
[seoulmetro/l5.json](https://uat-railmapgen.github.io/rmg/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F6a9c568d988cff524ec37325b1b4291ea069bd3f%2Fpublic%2Fresources%2Ftemplates%2Fseoulmetro%2Fl5.json)