### PR TITLE
Resources: New templates of Beijing Subway

### DIFF
--- a/public/resources/templates/bjsubway/00config.json
+++ b/public/resources/templates/bjsubway/00config.json
@@ -43,9 +43,9 @@
         "filename": "bj6",
         "name": {
             "en": "Line 6",
-            "ko": "6호선",
             "zh-Hans": "6号线",
-            "zh-Hant": "6號線"
+            "zh-Hant": "6號線",
+            "ko": "6호선"
         },
         "uploadBy": "AnDanJuneUnderline"
     },

--- a/public/resources/templates/bjsubway/bj6.json
+++ b/public/resources/templates/bjsubway/bj6.json
@@ -469,7 +469,9 @@
                 "Opening soon"
             ],
             "num": "11",
-            "services": [],
+            "services": [
+                "local"
+            ],
             "parents": [
                 "8dh38v"
             ],


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Beijing Subway on behalf of 52PD.
This should fix #214

**Review links**
[bjsubway/bj6.json](https://uat-railmapgen.github.io/rmg/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F8b9ba6b0974499387ebf0262d8d51617886c3a42%2Fpublic%2Fresources%2Ftemplates%2Fbjsubway%2Fbj6.json)