### PR TITLE
Resources: New templates of Seoul Metropolitan Subway

### DIFF
--- a/public/resources/templates/seoulmetro/00config.json
+++ b/public/resources/templates/seoulmetro/00config.json
@@ -113,9 +113,9 @@
         "filename": "suinbundang",
         "name": {
             "en": "Suin-Bundang Line",
-            "ko": "수인·분당선",
             "zh-Hans": "水仁·盆唐线",
-            "zh-Hant": "水仁·盆唐線"
+            "zh-Hant": "水仁·盆唐線",
+            "ko": "수인·분당선"
         },
         "uploadBy": "WOLFRAZOR"
     },

--- a/public/resources/templates/seoulmetro/suinbundang.json
+++ b/public/resources/templates/seoulmetro/suinbundang.json
@@ -273,6 +273,7 @@
             },
             "transfer": {
                 "info": [
+                    [],
                     [
                         [
                             "seoul",
@@ -2129,6 +2130,7 @@
             },
             "transfer": {
                 "info": [
+                    [],
                     [
                         [
                             "seoul",
@@ -2136,7 +2138,7 @@
                             "#D4003B",
                             "#fff",
                             "신분당선",
-                            "Shinbundang Line"
+                            "Shinbundang"
                         ]
                     ]
                 ],
@@ -2171,6 +2173,7 @@
             },
             "transfer": {
                 "info": [
+                    [],
                     [
                         [
                             "seoul",
@@ -2178,7 +2181,7 @@
                             "#D4003B",
                             "#fff",
                             "신분당선",
-                            "Shinbundang Line"
+                            "Shinbundang"
                         ]
                     ]
                 ],


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Seoul Metropolitan Subway on behalf of WOLFRAZOR.
This should fix #219

**Review links**
[seoulmetro/suinbundang.json](https://uat-railmapgen.github.io/rmg/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fd7743069c185bf2cf4539ed9f952c0fdb7f7a9e1%2Fpublic%2Fresources%2Ftemplates%2Fseoulmetro%2Fsuinbundang.json)