### PR TITLE
Resources: New templates of Seoul Metropolitan Subway

### DIFF
--- a/public/resources/templates/seoulmetro/00config.json
+++ b/public/resources/templates/seoulmetro/00config.json
@@ -153,9 +153,9 @@
         "filename": "shl",
         "name": {
             "en": "Seo Hae Line",
-            "ko": "서해선",
             "zh-Hans": "西海线",
-            "zh-Hant": "西海線"
+            "zh-Hant": "西海線",
+            "ko": "서해선"
         },
         "uploadBy": "WOLFRAZOR"
     },

--- a/public/resources/templates/seoulmetro/shl.json
+++ b/public/resources/templates/seoulmetro/shl.json
@@ -5,8 +5,8 @@
         "railmap": 1500,
         "indoor": 1200
     },
-    "svg_height": 500,
-    "style": "gzmtr",
+    "svg_height": 800,
+    "style": "shmetro",
     "y_pc": 50,
     "padding": 10,
     "branchSpacingPct": 33,
@@ -22,7 +22,7 @@
         "西海线",
         "Seo Hae Line"
     ],
-    "current_stn_idx": "aU6UcP",
+    "current_stn_idx": "IW6Du1",
     "stn_list": {
         "linestart": {
             "name": [
@@ -36,7 +36,7 @@
             ],
             "parents": [],
             "children": [
-                "rULbf_"
+                "foCv-Z"
             ],
             "branch": {
                 "left": [],
@@ -66,7 +66,7 @@
                 "local"
             ],
             "parents": [
-                "linestart"
+                "hdVcug"
             ],
             "children": [
                 "yRTeq2"
@@ -516,6 +516,346 @@
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
+        },
+        "k8hbcR": {
+            "name": [
+                "谷山",
+                "곡산 \\Goksan"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "LG3Ten"
+            ],
+            "children": [
+                "rGOfUW"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "rGOfUW": {
+            "name": [
+                "大谷",
+                "대곡 \\Daegok"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "k8hbcR"
+            ],
+            "children": [
+                "6BmnCT"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    [
+                        [
+                            "seoul",
+                            "su3",
+                            "#fe5b10",
+                            "#fff",
+                            "3호선",
+                            "Line 3"
+                        ]
+                    ]
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "6BmnCT": {
+            "name": [
+                "陵谷",
+                "능곡 \\Neunggok"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "rGOfUW"
+            ],
+            "children": [
+                "IW6Du1"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "IW6Du1": {
+            "name": [
+                "金浦机场",
+                "김포공항 \\Gimpo Int'l Airport"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "6BmnCT"
+            ],
+            "children": [
+                "jVU1Bs"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    [
+                        [
+                            "seoul",
+                            "su5",
+                            "#8b50a4",
+                            "#fff",
+                            "5호선",
+                            "Line 5"
+                        ],
+                        [
+                            "seoul",
+                            "su9",
+                            "#aa9872",
+                            "#fff",
+                            "9호선",
+                            "Line 9"
+                        ],
+                        [
+                            "seoul",
+                            "arx",
+                            "#3681b7",
+                            "#fff",
+                            "인천국제공항철도",
+                            "Airport Railroad Express"
+                        ]
+                    ]
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "jVU1Bs": {
+            "name": [
+                "遠宗",
+                "원종 \\Wonjong"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "IW6Du1"
+            ],
+            "children": [
+                "hdVcug"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "hdVcug": {
+            "name": [
+                "富川综合运动场",
+                "부천종합운동장 \\Bucheon Stadium"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "jVU1Bs"
+            ],
+            "children": [
+                "rULbf_"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    [
+                        [
+                            "seoul",
+                            "su7",
+                            "#54640d",
+                            "#fff",
+                            "7호선",
+                            "Line 7"
+                        ]
+                    ]
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "foCv-Z": {
+            "name": [
+                "一山",
+                "일산 \\Ilsan"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "nbi5Zr"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "nbi5Zr": {
+            "name": [
+                "枫山",
+                "풍산 \\Pungsan"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "foCv-Z"
+            ],
+            "children": [
+                "LG3Ten"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "LG3Ten": {
+            "name": [
+                "白马",
+                "백마 \\Baengma"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "nbi5Zr"
+            ],
+            "children": [
+                "k8hbcR"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
         }
     },
     "namePosMTR": {
@@ -532,7 +872,23 @@
     "notesGZMTR": [],
     "direction_gz_x": 40,
     "direction_gz_y": 70,
-    "coline": {},
+    "coline": {
+        "HEIX": {
+            "from": "foCv-Z",
+            "to": "6BmnCT",
+            "colors": [
+                [
+                    "seoul",
+                    "gj",
+                    "#72c7a6",
+                    "#fff",
+                    "경의·중앙선",
+                    "Gyeongui–Jungang Line"
+                ]
+            ],
+            "display": true
+        }
+    },
     "loop": false,
     "loop_info": {
         "bank": true,


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Seoul Metropolitan Subway on behalf of WOLFRAZOR.
This should fix #245

**Review links**
[seoulmetro/shl.json](https://uat-railmapgen.github.io/rmg/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fc6cc85cb22b8e18f6bb802b07c3719396aa3a4dc%2Fpublic%2Fresources%2Ftemplates%2Fseoulmetro%2Fshl.json)