### PR TITLE
Resources: New templates of Nanjing Metro

### DIFF
--- a/public/resources/templates/njmetro/00config.json
+++ b/public/resources/templates/njmetro/00config.json
@@ -65,9 +65,10 @@
     {
         "filename": "njs3",
         "name": {
-            "en": "Line S6",
+            "en": "Line S3",
             "zh-Hans": "S3号线",
-            "zh-Hant": "S3號線"
+            "zh-Hant": "S3號線",
+            "ko": " "
         },
         "uploadBy": "njmetro-jxzb"
     },

--- a/public/resources/templates/njmetro/njs3.json
+++ b/public/resources/templates/njmetro/njs3.json
@@ -2,7 +2,7 @@
     "svgWidth": {
         "destination": 1200,
         "runin": 1200,
-        "railmap": 1200,
+        "railmap": 1500,
         "indoor": 1200
     },
     "svg_height": 300,
@@ -58,7 +58,7 @@
         "ygSZqL": {
             "name": [
                 "南京南站",
-                "Nanjing South Railway Station"
+                "NANJING SOUTH RAILWAY STATION"
             ],
             "secondaryName": false,
             "num": "01",
@@ -100,11 +100,11 @@
                             "#00b2a9",
                             "#fff",
                             "S1号线",
-                            "Line S3"
+                            "Line S1"
                         ]
                     ]
                 ],
-                "tick_direc": "r",
+                "tick_direc": "l",
                 "paid_area": true,
                 "osi_names": []
             },


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Nanjing Metro on behalf of ChemistryLLC.
This should fix #260

**Review links**
[njmetro/njs3.json](https://uat-railmapgen.github.io/rmg/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fbf2f53383b0c32167e3e6b43c106c5964b8d098e%2Fpublic%2Fresources%2Ftemplates%2Fnjmetro%2Fnjs3.json)