### PR TITLE
Resources: New templates of Changsha Metro

### DIFF
--- a/public/resources/templates/hncsmtr/00config.json
+++ b/public/resources/templates/hncsmtr/00config.json
@@ -18,5 +18,14 @@
             "ko": "라인 2"
         },
         "uploadBy": "Windows-Taskmgr"
+    },
+    {
+        "filename": "maglevexpress",
+        "name": {
+            "en": "Maglev Express",
+            "zh-Hans": "磁浮快线",
+            "zh-Hant": "磁浮快線"
+        },
+        "uploadBy": "Windows-Taskmgr"
     }
 ]

--- a/public/resources/templates/hncsmtr/maglevexpress.json
+++ b/public/resources/templates/hncsmtr/maglevexpress.json
@@ -1,0 +1,265 @@
+{
+    "style": "shmetro",
+    "svg_height": 350,
+    "padding": 13,
+    "y_pc": 40,
+    "theme": [
+        "changsha",
+        "maglev",
+        "#F891A5",
+        "#fff"
+    ],
+    "direction": "l",
+    "current_stn_idx": "iwf6",
+    "platform_num": "3",
+    "stn_list": {
+        "linestart": {
+            "parents": [],
+            "children": [
+                "l1mz"
+            ],
+            "name": [
+                "路綫左端",
+                "LEFT END"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ]
+            },
+            "services": [
+                "local"
+            ],
+            "facility": "",
+            "num": "00",
+            "secondaryName": false,
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 125
+        },
+        "lineend": {
+            "parents": [
+                "6F6hXp"
+            ],
+            "children": [],
+            "name": [
+                "路綫右端",
+                "RIGHT END"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ]
+            },
+            "services": [
+                "local"
+            ],
+            "facility": "",
+            "num": "00",
+            "secondaryName": false,
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 125
+        },
+        "l1mz": {
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "iwf6"
+            ],
+            "name": [
+                "磁浮高铁站",
+                "Changshanan Maglev Station"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "num": "02",
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": []
+                    },
+                    {
+                        "lines": []
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "changsha",
+                                    "cs2",
+                                    "#8DC8E8",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "2号线",
+                                    "Line 2"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "changsha",
+                                    "cs4",
+                                    "#A51890",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "4号线",
+                                    "Line 4"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "services": [
+                "local"
+            ],
+            "facility": "railway",
+            "secondaryName": false,
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 125
+        },
+        "iwf6": {
+            "children": [
+                "6F6hXp"
+            ],
+            "parents": [
+                "l1mz"
+            ],
+            "name": [
+                "磁浮㮾梨站",
+                "Langli Maglev Station"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "num": "01",
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ]
+            },
+            "services": [
+                "local"
+            ],
+            "facility": "",
+            "secondaryName": false,
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 125
+        },
+        "6F6hXp": {
+            "name": [
+                "磁浮机场站",
+                "Huanghua Airport Maglev Station"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "iwf6"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": []
+                    },
+                    {
+                        "lines": []
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "changsha",
+                                    "cs6",
+                                    "#0077C8",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "6号线",
+                                    "Line 6"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "facility": "airport",
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 125
+        }
+    },
+    "line_name": [
+        "磁浮快线",
+        "Maglev Express"
+    ],
+    "psd_num": "1",
+    "line_num": "TW",
+    "info_panel_type": "gz28",
+    "direction_gz_x": 50,
+    "direction_gz_y": 70,
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "svgWidth": {
+        "destination": 1300,
+        "runin": 1300,
+        "railmap": 1300,
+        "indoor": 1300
+    },
+    "notesGZMTR": [],
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": false
+    },
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 0,
+        "bottom_factor": 1
+    },
+    "branchSpacingPct": 43
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Changsha Metro on behalf of Windows-Taskmgr.
This should fix #392

**Review links**
[hncsmtr/maglevexpress.json](https://uat-railmapgen.github.io/rmg/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fc8a21f028df1f77df3acfd08a7d17d2081fd1fbc%2Fpublic%2Fresources%2Ftemplates%2Fhncsmtr%2Fmaglevexpress.json)