### PR TITLE
Resources: New templates of Nanjing Metro

### DIFF
--- a/public/resources/templates/njmetro/00config.json
+++ b/public/resources/templates/njmetro/00config.json
@@ -33,7 +33,7 @@
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
         },
-        "uploadBy": "linchen1965"
+        "uploadBy": "ACS-resources"
     },
     {
         "filename": "nj7",
@@ -51,7 +51,7 @@
             "zh-Hans": "10号线",
             "zh-Hant": "10號線"
         },
-        "uploadBy": "linchen1965"
+        "uploadBy": "ACS-resources"
     },
     {
         "filename": "njs1",

--- a/public/resources/templates/njmetro/nj1.json
+++ b/public/resources/templates/njmetro/nj1.json
@@ -18,7 +18,7 @@
         "linestart": {
             "parents": [],
             "children": [
-                "qdg7"
+                "dyey"
             ],
             "name": [
                 "路綫左端",
@@ -193,8 +193,16 @@
                         ],
                         [
                             "nanjing",
+                            "nj6",
+                            "#00b2a9",
+                            "#fff",
+                            "6号线",
+                            "Line 6"
+                        ],
+                        [
+                            "nanjing",
                             "s1",
-                            "#4BBBB4",
+                            "#00b2a9",
                             "#fff",
                             "机场线",
                             "Airport Line"
@@ -202,7 +210,7 @@
                         [
                             "nanjing",
                             "s3",
-                            "#BA84AC",
+                            "#b06096",
                             "#fff",
                             "宁和线",
                             "Ninghe Line"
@@ -396,7 +404,16 @@
                 "paid_area": true,
                 "osi_names": [],
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj5",
+                            "#FDDA24",
+                            "#fff",
+                            "5号线",
+                            "Line 5"
+                        ]
+                    ]
                 ]
             },
             "services": [
@@ -632,6 +649,14 @@
                             "#fff",
                             "3号线",
                             "Line 3"
+                        ],
+                        [
+                            "nanjing",
+                            "nj9",
+                            "#fa4616",
+                            "#fff",
+                            "9号线",
+                            "Line 9"
                         ]
                     ]
                 ]
@@ -678,7 +703,7 @@
                 "right": []
             },
             "parents": [
-                "linestart"
+                "5k8z"
             ],
             "children": [
                 "y0h6"
@@ -784,7 +809,16 @@
             },
             "transfer": {
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj5",
+                            "#FDDA24",
+                            "#fff",
+                            "5号线",
+                            "Line 5"
+                        ]
+                    ]
                 ],
                 "tick_direc": "r",
                 "paid_area": true,
@@ -941,6 +975,165 @@
                 "osi_names": []
             },
             "facility": ""
+        },
+        "5k8z": {
+            "name": [
+                "晓庄",
+                "Xiaozhuang"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "h0au"
+            ],
+            "children": [
+                "qdg7"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    [
+                        [
+                            "nanjing",
+                            "nj7",
+                            "#4A7729",
+                            "#fff",
+                            "7号线",
+                            "Line 7"
+                        ]
+                    ]
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "h0au": {
+            "name": [
+                "吉祥庵",
+                "Jixiang'an"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "d5d8"
+            ],
+            "children": [
+                "5k8z"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "d5d8": {
+            "name": [
+                "燕子矶",
+                "Yanziji"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "hb3e"
+            ],
+            "children": [
+                "h0au"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "hb3e": {
+            "name": [
+                "笆斗山",
+                "Badoushan"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "dyey"
+            ],
+            "children": [
+                "d5d8"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "dyey": {
+            "name": [
+                "八卦洲大桥南",
+                "Baguazhoudaqiaonan"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "hb3e"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
         }
     },
     "line_name": [
@@ -958,7 +1151,8 @@
     "svgWidth": {
         "destination": 1000,
         "runin": 1510,
-        "railmap": 2021
+        "railmap": 2021,
+        "indoor": 2021
     },
     "notesGZMTR": [],
     "namePosMTR": {

--- a/public/resources/templates/njmetro/nj10.json
+++ b/public/resources/templates/njmetro/nj10.json
@@ -104,7 +104,7 @@
         },
         "lineend": {
             "parents": [
-                "kxo3"
+                "tp51"
             ],
             "children": [],
             "name": [
@@ -310,7 +310,16 @@
             },
             "transfer": {
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj11",
+                            "#ef426f",
+                            "#fff",
+                            "11号线",
+                            "Line 11"
+                        ]
+                    ]
                 ],
                 "tick_direc": "r",
                 "paid_area": true,
@@ -400,7 +409,16 @@
             },
             "transfer": {
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj9",
+                            "#fa4616",
+                            "#fff",
+                            "9号线",
+                            "Line 9"
+                        ]
+                    ]
                 ],
                 "tick_direc": "r",
                 "paid_area": true,
@@ -431,7 +449,16 @@
             },
             "transfer": {
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj7",
+                            "#4A7729",
+                            "#fff",
+                            "7号线",
+                            "Line 7"
+                        ]
+                    ]
                 ],
                 "tick_direc": "r",
                 "paid_area": true,
@@ -483,7 +510,7 @@
                 "bm8i"
             ],
             "children": [
-                "lineend"
+                "cxjk"
             ],
             "branch": {
                 "left": [],
@@ -501,6 +528,324 @@
                             "Line 1"
                         ]
                     ]
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "cxjk": {
+            "name": [
+                "共青团路",
+                "Gongqingtuanlu"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "kxo3"
+            ],
+            "children": [
+                "ky0o"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "ky0o": {
+            "name": [
+                "雨花台",
+                "Yuhuatai"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "cxjk"
+            ],
+            "children": [
+                "hceg"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "hceg": {
+            "name": [
+                "卡子门",
+                "Kazimen"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ky0o"
+            ],
+            "children": [
+                "s4mr"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    [
+                        [
+                            "nanjing",
+                            "nj3",
+                            "#009a44",
+                            "#fff",
+                            "3号线",
+                            "Line 3"
+                        ]
+                    ]
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "s4mr": {
+            "name": [
+                "机场跑道旧址",
+                "Jichangpaodaojiuzhi"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "hceg"
+            ],
+            "children": [
+                "1o31"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "1o31": {
+            "name": [
+                "大校场",
+                "Dajiaochang"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "s4mr"
+            ],
+            "children": [
+                "t1e2"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    [
+                        [
+                            "nanjing",
+                            "nj5",
+                            "#FDDA24",
+                            "#fff",
+                            "5号线",
+                            "Line 5"
+                        ]
+                    ]
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "t1e2": {
+            "name": [
+                "承天大道",
+                "Chengtiandadao"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "1o31"
+            ],
+            "children": [
+                "iwoa"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "iwoa": {
+            "name": [
+                "高桥门",
+                "Gaoqiaomen"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "t1e2"
+            ],
+            "children": [
+                "d9gt"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "d9gt": {
+            "name": [
+                "杨庄",
+                "Yangzhuang"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "iwoa"
+            ],
+            "children": [
+                "n5kn"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "n5kn": {
+            "name": [
+                "石杨路",
+                "Shiyanglu"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "d9gt"
+            ],
+            "children": [
+                "tp51"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "tp51": {
+            "name": [
+                "东麒路",
+                "Dongqilu"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "n5kn"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
                 ],
                 "tick_direc": "r",
                 "paid_area": true,
@@ -525,7 +870,8 @@
     "svgWidth": {
         "destination": 1000,
         "runin": 1000,
-        "railmap": 1000
+        "railmap": 1000,
+        "indoor": 1000
     },
     "notesGZMTR": [],
     "namePosMTR": {

--- a/public/resources/templates/njmetro/nj2.json
+++ b/public/resources/templates/njmetro/nj2.json
@@ -280,7 +280,16 @@
                 "paid_area": true,
                 "osi_names": [],
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj6",
+                            "#00b2a9",
+                            "#fff",
+                            "6号线",
+                            "Line 6"
+                        ]
+                    ]
                 ]
             },
             "services": [
@@ -418,7 +427,16 @@
                 "paid_area": true,
                 "osi_names": [],
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj5",
+                            "#FDDA24",
+                            "#fff",
+                            "5号线",
+                            "Line 5"
+                        ]
+                    ]
                 ]
             },
             "services": [
@@ -478,7 +496,16 @@
                 "paid_area": true,
                 "osi_names": [],
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj7",
+                            "#4A7729",
+                            "#fff",
+                            "7号线",
+                            "Line 7"
+                        ]
+                    ]
                 ]
             },
             "services": [
@@ -742,7 +769,16 @@
                 "paid_area": true,
                 "osi_names": [],
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj7",
+                            "#4A7729",
+                            "#fff",
+                            "7号线",
+                            "Line 7"
+                        ]
+                    ]
                 ]
             },
             "services": [
@@ -1047,7 +1083,8 @@
     "svgWidth": {
         "destination": 1100,
         "runin": 1143,
-        "railmap": 2021
+        "railmap": 2021,
+        "indoor": 2021
     },
     "notesGZMTR": [],
     "namePosMTR": {

--- a/public/resources/templates/njmetro/nj3.json
+++ b/public/resources/templates/njmetro/nj3.json
@@ -17,7 +17,7 @@
         "linestart": {
             "parents": [],
             "children": [
-                "kwag"
+                "8g5s"
             ],
             "name": [
                 "路綫右端",
@@ -44,7 +44,7 @@
         },
         "lineend": {
             "parents": [
-                "dx9v"
+                "v3be"
             ],
             "children": [],
             "name": [
@@ -84,7 +84,7 @@
                 "507q"
             ],
             "children": [
-                "lineend"
+                "exha"
             ],
             "branch": {
                 "left": [],
@@ -152,7 +152,16 @@
             },
             "transfer": {
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj5",
+                            "#FDDA24",
+                            "#fff",
+                            "5号线",
+                            "Line 5"
+                        ]
+                    ]
                 ],
                 "tick_direc": "r",
                 "paid_area": true,
@@ -313,8 +322,16 @@
                         ],
                         [
                             "nanjing",
+                            "nj6",
+                            "#00b2a9",
+                            "#fff",
+                            "6号线",
+                            "Line 6"
+                        ],
+                        [
+                            "nanjing",
                             "s1",
-                            "#4BBBB4",
+                            "#00b2a9",
                             "#fff",
                             "机场线",
                             "Airport Line"
@@ -322,7 +339,7 @@
                         [
                             "nanjing",
                             "s3",
-                            "#BA84AC",
+                            "#b06096",
                             "#fff",
                             "宁和线",
                             "Ninghe Line"
@@ -516,7 +533,16 @@
             },
             "transfer": {
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj5",
+                            "#FDDA24",
+                            "#fff",
+                            "5号线",
+                            "Line 5"
+                        ]
+                    ]
                 ],
                 "tick_direc": "r",
                 "paid_area": true,
@@ -692,6 +718,14 @@
                             "#fff",
                             "1号线",
                             "Line 1"
+                        ],
+                        [
+                            "nanjing",
+                            "nj9",
+                            "#fa4616",
+                            "#fff",
+                            "9号线",
+                            "Line 9"
                         ]
                     ]
                 ],
@@ -783,7 +817,16 @@
             },
             "transfer": {
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj7",
+                            "#4A7729",
+                            "#fff",
+                            "7号线",
+                            "Line 7"
+                        ]
+                    ]
                 ],
                 "tick_direc": "r",
                 "paid_area": true,
@@ -843,7 +886,16 @@
             },
             "transfer": {
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj11",
+                            "#ef426f",
+                            "#fff",
+                            "11号线",
+                            "Line 11"
+                        ]
+                    ]
                 ],
                 "tick_direc": "r",
                 "paid_area": true,
@@ -991,10 +1043,109 @@
                 "local"
             ],
             "parents": [
-                "linestart"
+                "8g5s"
             ],
             "children": [
                 "xh2v"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "8g5s": {
+            "name": [
+                "南京北站",
+                "Nanjing North Railway Station"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "kwag"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    [
+                        [
+                            "nanjing",
+                            "s4",
+                            "#B5BF3B",
+                            "#fff",
+                            "宁滁线",
+                            "Ningchu Line"
+                        ]
+                    ]
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "exha": {
+            "name": [
+                "和风路·上秦淮西",
+                "Hefenglu/Shangqinhuaixi"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "dx9v"
+            ],
+            "children": [
+                "v3be"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "v3be": {
+            "name": [
+                "秣陵街道",
+                "Molingjiedao"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "exha"
+            ],
+            "children": [
+                "lineend"
             ],
             "branch": {
                 "left": [],
@@ -1027,7 +1178,8 @@
     "svgWidth": {
         "destination": 2000,
         "runin": 1143,
-        "railmap": 2021
+        "railmap": 2021,
+        "indoor": 2021
     },
     "notesGZMTR": [],
     "namePosMTR": {

--- a/public/resources/templates/njmetro/nj4.json
+++ b/public/resources/templates/njmetro/nj4.json
@@ -17,7 +17,7 @@
         "linestart": {
             "parents": [],
             "children": [
-                "eg1z"
+                "tntb"
             ],
             "name": [
                 "路綫右端",
@@ -91,7 +91,16 @@
                 "paid_area": true,
                 "osi_names": [],
                 "info": [
-                    []
+                    [
+                        [
+                            "other",
+                            "other",
+                            "#AAAAAa",
+                            "#fff",
+                            "宁仪扬线",
+                            "Ningyiyang Line"
+                        ]
+                    ]
                 ]
             },
             "services": [
@@ -121,7 +130,16 @@
                 "paid_area": true,
                 "osi_names": [],
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj5",
+                            "#FDDA24",
+                            "#fff",
+                            "5号线",
+                            "Line 5"
+                        ]
+                    ]
                 ]
             },
             "services": [
@@ -259,7 +277,16 @@
                 "paid_area": true,
                 "osi_names": [],
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj6",
+                            "#00b2a9",
+                            "#fff",
+                            "6号线",
+                            "Line 6"
+                        ]
+                    ]
                 ]
             },
             "services": [
@@ -599,7 +626,16 @@
             },
             "transfer": {
                 "info": [
-                    []
+                    [
+                        [
+                            "nanjing",
+                            "nj7",
+                            "#4A7729",
+                            "#fff",
+                            "7号线",
+                            "Line 7"
+                        ]
+                    ]
                 ],
                 "tick_direc": "r",
                 "paid_area": true,
@@ -618,7 +654,7 @@
                 "local"
             ],
             "parents": [
-                "linestart"
+                "wgei"
             ],
             "children": [
                 "qrv2"
@@ -629,7 +665,282 @@
             },
             "transfer": {
                 "info": [
+                    [
+                        [
+                            "nanjing",
+                            "nj9",
+                            "#fa4616",
+                            "#fff",
+                            "9号线",
+                            "Line 9"
+                        ]
+                    ]
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "wgei": {
+            "name": [
+                "江北市民中心",
+                "Jiangbei Citizen Center"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "xry8"
+            ],
+            "children": [
+                "eg1z"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
                     []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "xry8": {
+            "name": [
+                "江北商务区",
+                "Jiangbei Business District"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "261l"
+            ],
+            "children": [
+                "wgei"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    [
+                        [
+                            "nanjing",
+                            "nj11",
+                            "#ef426f",
+                            "#fff",
+                            "11号线",
+                            "Line 11"
+                        ]
+                    ]
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "261l": {
+            "name": [
+                "定山大街",
+                "Dingshandajie"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "88qk"
+            ],
+            "children": [
+                "xry8"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "88qk": {
+            "name": [
+                "石佛寺",
+                "Shifosi"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "emag"
+            ],
+            "children": [
+                "261l"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "emag": {
+            "name": [
+                "瑞龙郊野公园",
+                "Ruilong Country Park"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "eays"
+            ],
+            "children": [
+                "88qk"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "eays": {
+            "name": [
+                "珍珠泉东",
+                "Pearl Spring East"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "3i2v"
+            ],
+            "children": [
+                "emag"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "3i2v": {
+            "name": [
+                "野生动物园",
+                "Wild Animal Zoo"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "tntb"
+            ],
+            "children": [
+                "eays"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    []
+                ],
+                "tick_direc": "r",
+                "paid_area": true,
+                "osi_names": []
+            },
+            "facility": ""
+        },
+        "tntb": {
+            "name": [
+                "南京北站",
+                "Nanjing North Railway Station"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "3i2v"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "info": [
+                    [
+                        [
+                            "nanjing",
+                            "nj3",
+                            "#009651",
+                            "#fff",
+                            "3号线",
+                            "Line 3"
+                        ],
+                        [
+                            "nanjing",
+                            "s4",
+                            "#B5BF3B",
+                            "#fff",
+                            "宁滁线",
+                            "Ningchu Line"
+                        ]
+                    ]
                 ],
                 "tick_direc": "r",
                 "paid_area": true,


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Nanjing Metro on behalf of ACS-resources.
This should fix #413

**Review links**
[njmetro/nj1.json](https://uat-railmapgen.github.io/rmg/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F0194ae863ea072a35e12b6acfe77b3d972d8ca89%2Fpublic%2Fresources%2Ftemplates%2Fnjmetro%2Fnj1.json)
[njmetro/nj2.json](https://uat-railmapgen.github.io/rmg/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F0194ae863ea072a35e12b6acfe77b3d972d8ca89%2Fpublic%2Fresources%2Ftemplates%2Fnjmetro%2Fnj2.json)
[njmetro/nj3.json](https://uat-railmapgen.github.io/rmg/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F0194ae863ea072a35e12b6acfe77b3d972d8ca89%2Fpublic%2Fresources%2Ftemplates%2Fnjmetro%2Fnj3.json)
[njmetro/nj4.json](https://uat-railmapgen.github.io/rmg/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F0194ae863ea072a35e12b6acfe77b3d972d8ca89%2Fpublic%2Fresources%2Ftemplates%2Fnjmetro%2Fnj4.json)
[njmetro/nj10.json](https://uat-railmapgen.github.io/rmg/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F0194ae863ea072a35e12b6acfe77b3d972d8ca89%2Fpublic%2Fresources%2Ftemplates%2Fnjmetro%2Fnj10.json)