### PR TITLE
Resources: New templates of SNCF

### DIFF
--- a/public/resources/templates/sncf/rere.json
+++ b/public/resources/templates/sncf/rere.json
@@ -20,7 +20,7 @@
     ],
     "line_name": [
         "RER快铁E线",
-        "Ligne A du RER d'Île-de-France"
+        "Ligne E du RER d'Île-de-France"
     ],
     "current_stn_idx": "a1-HZ2",
     "stn_list": {


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of SNCF on behalf of polygon827.
This should fix #541

**Review links**
[sncf/rere.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F5b3274e189f7ac2203200ba045e26411cbadc9dc%2Fpublic%2Fresources%2Ftemplates%2Fsncf%2Frere.json)