### PR TITLE
Resources: New templates of RATP

### DIFF
--- a/public/resources/templates/ratp/00config.json
+++ b/public/resources/templates/ratp/00config.json
@@ -98,5 +98,15 @@
             "fr": "Ligne 14"
         },
         "uploadBy": "polygon827"
+    },
+    {
+        "filename": "orlyval",
+        "name": {
+            "en": "OrlyVal",
+            "zh-Hans": "奥利机场轻轨",
+            "zh-Hant": "奧利機場輕軌",
+            "fr": "OrlyVal"
+        },
+        "uploadBy": "polygon827"
     }
 ]

--- a/public/resources/templates/ratp/orlyval.json
+++ b/public/resources/templates/ratp/orlyval.json
@@ -1,0 +1,228 @@
+{
+    "svgWidth": {
+        "destination": 1200,
+        "runin": 1200,
+        "railmap": 1200,
+        "indoor": 1200
+    },
+    "svg_height": 300,
+    "style": "mtr",
+    "y_pc": 50,
+    "padding": 10,
+    "branchSpacingPct": 33,
+    "direction": "r",
+    "platform_num": "1",
+    "theme": [
+        "paris",
+        "orv",
+        "#FFCD0D",
+        "#fff"
+    ],
+    "line_name": [
+        "奥利机场轻轨",
+        "OrlyVal"
+    ],
+    "current_stn_idx": "BDTIU1",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "BDTIU1"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "BDTIU1": {
+            "name": [
+                "安东尼",
+                "Antony"
+            ],
+            "secondaryName": false,
+            "num": "01",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "wDNrRw"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "paris",
+                                    "rerb",
+                                    "#5291CE",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "RER快铁B线",
+                                    "Ligne B du RER d'Île-de-France"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "wDNrRw": {
+            "name": [
+                "奥利机场1/2/3号航站楼",
+                "Orly 1,2,3"
+            ],
+            "secondaryName": false,
+            "num": "02",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "BDTIU1"
+            ],
+            "children": [
+                "4GWWu1"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "airport",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "4GWWu1"
+            ],
+            "children": [],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "4GWWu1": {
+            "name": [
+                "奥利机场4号航站楼",
+                "Orly 4"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "wDNrRw"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "airport",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": true
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "1",
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "notesGZMTR": [],
+    "direction_gz_x": 40,
+    "direction_gz_y": 70,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    }
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of RATP on behalf of polygon827.
This should fix #543

**Review links**
[ratp/orlyval.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F242c05a3b0c258365c44568a9a660b23a743c4f0%2Fpublic%2Fresources%2Ftemplates%2Fratp%2Forlyval.json)