### PR TITLE
Resources: New templates of Shanghai Metro

### DIFF
--- a/public/resources/templates/shmetro/00config.json
+++ b/public/resources/templates/shmetro/00config.json
@@ -123,7 +123,7 @@
         "filename": "sh12",
         "name": {
             "en": "Line 12",
-             "ko": "12호선",
+            "ko": "12호선",
             "zh-Hans": "12号线",
             "zh-Hant": "12號線"
         },
@@ -188,5 +188,15 @@
             "zh-Hant": "18號線"
         },
         "uploadBy": "Tianxiu11111"
+    },
+    {
+        "filename": "shmg",
+        "name": {
+            "en": "Maglev Line",
+            "zh-Hans": "磁浮线",
+            "zh-Hant": "磁浮綫",
+            "ko": "자기부상선"
+        },
+        "uploadBy": "polygon827"
     }
 ]

--- a/public/resources/templates/shmetro/shmg.json
+++ b/public/resources/templates/shmetro/shmg.json
@@ -1,0 +1,249 @@
+{
+    "svgWidth": {
+        "destination": 1200,
+        "runin": 1200,
+        "railmap": 2000,
+        "indoor": 1200
+    },
+    "svg_height": 300,
+    "style": "shmetro",
+    "y_pc": 50,
+    "padding": 10,
+    "branchSpacingPct": 33,
+    "direction": "l",
+    "platform_num": "",
+    "theme": [
+        "shanghai",
+        "maglev",
+        "#009090",
+        "#fff"
+    ],
+    "line_name": [
+        "磁浮线",
+        "Maglev Line"
+    ],
+    "current_stn_idx": "8Nvwy3",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "Tz2gj3"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Tz2gj3": {
+            "name": [
+                "龙阳路",
+                "Longyang Rd."
+            ],
+            "secondaryName": false,
+            "num": "01",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "8Nvwy3"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "shanghai",
+                                    "sh2",
+                                    "#8CC220",
+                                    "#000"
+                                ],
+                                "name": [
+                                    "2号线",
+                                    "Line 2"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "shanghai",
+                                    "sh7",
+                                    "#ED6F00",
+                                    "#000"
+                                ],
+                                "name": [
+                                    "7号线",
+                                    "Line 7"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "shanghai",
+                                    "sh16",
+                                    "#98D1C0",
+                                    "#000"
+                                ],
+                                "name": [
+                                    "16号线",
+                                    "Line 16"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "shanghai",
+                                    "sh18",
+                                    "#C4984F",
+                                    "#000"
+                                ],
+                                "name": [
+                                    "18号线",
+                                    "Line 18"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "8Nvwy3": {
+            "name": [
+                "浦东国际机场",
+                "Pudong Airport"
+            ],
+            "secondaryName": false,
+            "num": "02",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Tz2gj3"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "shanghai",
+                                    "sh2",
+                                    "#8CC220",
+                                    "#000"
+                                ],
+                                "name": [
+                                    "2号线",
+                                    "Line 2"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "airport",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 210
+        },
+        "lineend": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "8Nvwy3"
+            ],
+            "children": [],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": true
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "1",
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "notesGZMTR": [],
+    "direction_gz_x": 40,
+    "direction_gz_y": 70,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    }
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Shanghai Metro on behalf of polygon827.
This should fix #549

**Review links**
[shmetro/shmg.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fdca8a7bbac6f4f3d276b286cb45bab36cfbe88fb%2Fpublic%2Fresources%2Ftemplates%2Fshmetro%2Fshmg.json)