### PR TITLE
Resources: New templates of Shanghai Metro

### DIFF
--- a/public/resources/templates/shmetro/00config.json
+++ b/public/resources/templates/shmetro/00config.json
@@ -197,5 +197,14 @@
             "zh-Hant": "浦江綫"
         },
         "uploadBy": "bobo45-1"
+    },
+    {
+        "filename": "shal",
+        "name": {
+            "en": "Airport Link Line",
+            "zh-Hans": "机场联络线",
+            "zh-Hant": "機場聯絡綫"
+        },
+        "uploadBy": "bobo45-1"
     }
 ]

--- a/public/resources/templates/shmetro/shal.json
+++ b/public/resources/templates/shmetro/shal.json
@@ -1,0 +1,480 @@
+{
+    "style": "shmetro",
+    "svg_height": 400,
+    "padding": 21,
+    "y_pc": 40,
+    "theme": [
+        "shanghai",
+        "airport",
+        "#266883",
+        "#fff"
+    ],
+    "direction": "l",
+    "current_stn_idx": "rph8",
+    "platform_num": "3",
+    "stn_list": {
+        "linestart": {
+            "parents": [],
+            "children": [
+                "l1mz"
+            ],
+            "name": [
+                "路綫左端",
+                "LEFT END"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ]
+            },
+            "services": [
+                "local"
+            ],
+            "facility": "",
+            "num": "00",
+            "secondaryName": false,
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 355
+        },
+        "lineend": {
+            "parents": [
+                "qu8l"
+            ],
+            "children": [],
+            "name": [
+                "路綫右端",
+                "RIGHT END"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ]
+            },
+            "services": [
+                "local"
+            ],
+            "facility": "",
+            "num": "00",
+            "secondaryName": false,
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 355
+        },
+        "l1mz": {
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "iwf6"
+            ],
+            "name": [
+                "虹桥火车站",
+                "Hongqiao Railway Station"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "num": "02",
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "shanghai",
+                                    "sh2",
+                                    "#97D700",
+                                    "#000"
+                                ],
+                                "name": [
+                                    "2号线",
+                                    "Line 2"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "shanghai",
+                                    "sh10",
+                                    "#C1A7E2",
+                                    "#000"
+                                ],
+                                "name": [
+                                    "10号线",
+                                    "Line 10"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "shanghai",
+                                    "sh17",
+                                    "#C09C83",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "17号线",
+                                    "Line 17"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "services": [
+                "local"
+            ],
+            "facility": "railway",
+            "secondaryName": false,
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 355
+        },
+        "iwf6": {
+            "children": [
+                "rmsc"
+            ],
+            "parents": [
+                "l1mz"
+            ],
+            "name": [
+                "中春路",
+                "Zhongchun Rd."
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "num": "01",
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "shanghai",
+                                    "sh9",
+                                    "#71C5E8",
+                                    "#000"
+                                ],
+                                "name": [
+                                    "9号线",
+                                    "Line 9"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "services": [
+                "local"
+            ],
+            "facility": "",
+            "secondaryName": false,
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 355
+        },
+        "rmsc": {
+            "name": [
+                "华泾西",
+                "West Huajing"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "iwf6"
+            ],
+            "children": [
+                "7sbd"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "shanghai",
+                                    "sh15",
+                                    "#BBA786",
+                                    "#000"
+                                ],
+                                "name": [
+                                    "15号线",
+                                    "Line 15"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 355
+        },
+        "7sbd": {
+            "name": [
+                "三林南",
+                "South Sanlin"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "rmsc"
+            ],
+            "children": [
+                "s20y"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ]
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 355
+        },
+        "s20y": {
+            "name": [
+                "张江",
+                "Zhangjiang"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "7sbd"
+            ],
+            "children": [
+                "rph8"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ]
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 355
+        },
+        "rph8": {
+            "name": [
+                "浦东国际机场",
+                "Pudong Int'l Airport"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "s20y"
+            ],
+            "children": [
+                "88h5"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "shanghai",
+                                    "sh2",
+                                    "#97D700",
+                                    "#000"
+                                ],
+                                "name": [
+                                    "2号线",
+                                    "Line 2"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": []
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "shanghai",
+                                    "maglev",
+                                    "#009090",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "磁浮线",
+                                    "Maglev Line"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "facility": "airport",
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 355
+        },
+        "88h5": {
+            "name": [
+                "浦东T3航站楼",
+                "Pudong Int'l Airport Terminal 3"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "rph8"
+            ],
+            "children": [
+                "qu8l"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ]
+            },
+            "facility": "airport",
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 355
+        },
+        "qu8l": {
+            "name": [
+                "上海东站",
+                "Shanghai East Railway Station"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "88h5"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "tick_direc": "r",
+                "paid_area": true,
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ]
+            },
+            "facility": "railway",
+            "loop_pivot": false,
+            "one_line": false,
+            "int_padding": 355
+        }
+    },
+    "line_name": [
+        "机场联络线",
+        "Airport Link Line"
+    ],
+    "psd_num": "1",
+    "line_num": "TW",
+    "info_panel_type": "sh",
+    "direction_gz_x": 50,
+    "direction_gz_y": 70,
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "svgWidth": {
+        "destination": 1500,
+        "runin": 1350,
+        "railmap": 1000,
+        "indoor": 1350
+    },
+    "notesGZMTR": [],
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": false
+    },
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    },
+    "branchSpacingPct": 34
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Shanghai Metro on behalf of bobo45-1.
This should fix #561

**Review links**
[shmetro/shal.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fffc3d5b2964a2815e85a23edc6f5068a8077d961%2Fpublic%2Fresources%2Ftemplates%2Fshmetro%2Fshal.json)