### PR TITLE
Resources: New templates of East Japan Railway Company

### DIFF
--- a/public/resources/other-company-config.json
+++ b/public/resources/other-company-config.json
@@ -159,6 +159,14 @@
         }
     },
     {
+        "id": "JREAST",
+        "name": {
+            "en": "East Japan Railway Company",
+            "zh-Hans": "东日本旅客铁道",
+            "zh-Hant": "東日本旅客鐵道"
+        }
+    },
+    {
         "id": "kmrailtransit",
         "name": {
             "en": "Kunming Rail Transit",

--- a/public/resources/templates/JREAST/00config.json
+++ b/public/resources/templates/JREAST/00config.json
@@ -1,0 +1,12 @@
+[
+    {
+        "filename": "JK",
+        "name": {
+            "en": "Keihin–Tōhoku Line",
+            "zh-Hans": "京滨东北线",
+            "zh-Hant": "京濱東北線",
+            "ja": "京浜東北線"
+        },
+        "uploadBy": "Takagi-Misae"
+    }
+]

--- a/public/resources/templates/JREAST/JK.json
+++ b/public/resources/templates/JREAST/JK.json
@@ -1,0 +1,3065 @@
+{
+    "svgWidth": {
+        "destination": 1200,
+        "runin": 1200,
+        "railmap": 10000,
+        "indoor": 20000
+    },
+    "svg_height": 500,
+    "style": "shmetro",
+    "y_pc": 30,
+    "padding": 4,
+    "branchSpacingPct": 33,
+    "direction": "r",
+    "platform_num": 1,
+    "theme": [
+        "tokyo",
+        "jk",
+        "#1DAED1",
+        "#fff"
+    ],
+    "line_name": [
+        "京浜東北線",
+        "Keihin–Tōhoku Line"
+    ],
+    "current_stn_idx": "V8nrMr",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "secondaryName": false,
+            "num": 0,
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "V8nrMr"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "FYa84J": {
+            "name": [
+                "大船",
+                "Ōfuna"
+            ],
+            "secondaryName": false,
+            "num": "46",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "wVeDLg"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jt",
+                                    "#F0862B",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東海道線",
+                                    "Tōkaidō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿ライン",
+                                    "Shōnan-Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jo",
+                                    "#1069B4",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横須賀線",
+                                    "Yokosuka Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jh",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横浜線",
+                                    "Yokohama Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "wVeDLg": {
+            "name": [
+                "\t本郷台",
+                "Hongōdai"
+            ],
+            "secondaryName": false,
+            "num": "45",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "cjyO_l"
+            ],
+            "children": [
+                "FYa84J"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jh",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横浜線",
+                                    "Yokohama Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "secondaryName": false,
+            "num": 0,
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "FYa84J"
+            ],
+            "children": [],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Z_y9Kw": {
+            "name": [
+                "根岸",
+                "Negishi"
+            ],
+            "secondaryName": false,
+            "num": "40",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "NvM1F7"
+            ],
+            "children": [
+                "u1nJvB"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "u1nJvB": {
+            "name": [
+                "磯子",
+                "Isogo"
+            ],
+            "secondaryName": false,
+            "num": "41",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Z_y9Kw"
+            ],
+            "children": [
+                "1aFnPZ"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "1aFnPZ": {
+            "name": [
+                "新杉田\t",
+                "Shin-Sugita"
+            ],
+            "secondaryName": false,
+            "num": "42",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "u1nJvB"
+            ],
+            "children": [
+                "gQgZNr"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jh",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横浜線",
+                                    "Yokohama Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "gQgZNr": {
+            "name": [
+                "洋光台",
+                "Yōkōdai"
+            ],
+            "secondaryName": false,
+            "num": "43",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "1aFnPZ"
+            ],
+            "children": [
+                "cjyO_l"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jh",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横浜線",
+                                    "Yokohama Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "cjyO_l": {
+            "name": [
+                "港南台",
+                "Kōnandai\t"
+            ],
+            "secondaryName": false,
+            "num": "44",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "gQgZNr"
+            ],
+            "children": [
+                "wVeDLg"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jh",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横浜線",
+                                    "Yokohama Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "ZLDFmm": {
+            "name": [
+                "高輪ゲートウェイ",
+                "Takanawa Gateway"
+            ],
+            "secondaryName": false,
+            "num": "27",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Vjcwaz"
+            ],
+            "children": [
+                "cqbVO1"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "a",
+                                    "#dd4231",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営浅草線",
+                                    "Toei Asakusa Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "kk",
+                                    "#00BFFF",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京急本線",
+                                    "Keikyu Main Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "泉岳寺",
+                            "Sengakuji"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "cqbVO1": {
+            "name": [
+                "品川",
+                "Shinagawa"
+            ],
+            "secondaryName": false,
+            "num": "28",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ZLDFmm"
+            ],
+            "children": [
+                "yD6PH3"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線 ",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jo",
+                                    "#1069B4",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横須賀線",
+                                    "Yokosuka Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jt",
+                                    "#F0862B",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東海道線",
+                                    "Tōkaidō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "kk",
+                                    "#00BFFF",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京急本線",
+                                    "Keikyū Main Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "yD6PH3": {
+            "name": [
+                "大井町",
+                "Ōimachi"
+            ],
+            "secondaryName": false,
+            "num": "29",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "cqbVO1"
+            ],
+            "children": [
+                "3UAxeb"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "r",
+                                    "#00418e",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "臨海線",
+                                    "Rinkai Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "om",
+                                    "#F18C43",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大井町線",
+                                    "Ōimachi Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "3UAxeb": {
+            "name": [
+                "大森",
+                "Ōmori"
+            ],
+            "secondaryName": false,
+            "num": "30",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "yD6PH3"
+            ],
+            "children": [
+                "XEBHmJ"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "XEBHmJ": {
+            "name": [
+                "\t蒲田",
+                "Kamata"
+            ],
+            "secondaryName": false,
+            "num": "31",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "3UAxeb"
+            ],
+            "children": [
+                "G40lL4"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ik",
+                                    "#EE86A8",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "池上線",
+                                    "Ikegami Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "tm",
+                                    "#AE0079",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "多摩川線",
+                                    "Tamagawa Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "G40lL4": {
+            "name": [
+                "川崎",
+                "Kawasaki"
+            ],
+            "secondaryName": false,
+            "num": "32",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "XEBHmJ"
+            ],
+            "children": [
+                "GgNE8D"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jt",
+                                    "#F0862B",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東海道線",
+                                    "Tōkaidō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jn",
+                                    "#F2D01F",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "南武線",
+                                    "Nambu Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "GgNE8D": {
+            "name": [
+                "鶴見",
+                "Tsurumi"
+            ],
+            "secondaryName": false,
+            "num": "33",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "G40lL4"
+            ],
+            "children": [
+                "Xnm421"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ji",
+                                    "#F2D01F",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "鶴見線",
+                                    "Tsurumi Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Xnm421": {
+            "name": [
+                "新子安",
+                "Shin-Koyasu"
+            ],
+            "secondaryName": false,
+            "num": "34",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "GgNE8D"
+            ],
+            "children": [
+                "jj37F2"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "jj37F2": {
+            "name": [
+                "東神奈川",
+                "Higashi-Kanagawa"
+            ],
+            "secondaryName": false,
+            "num": "35",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Xnm421"
+            ],
+            "children": [
+                "dm2B8G"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jh",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横浜線",
+                                    "Yokohama Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "dm2B8G": {
+            "name": [
+                "横浜",
+                "Yokohama"
+            ],
+            "secondaryName": false,
+            "num": "36",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "jj37F2"
+            ],
+            "children": [
+                "n2MXj9"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jt",
+                                    "#F0862B",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東海道線",
+                                    "Tōkaidō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿ライン",
+                                    "Shōnan-Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jo",
+                                    "#1069B4",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横須賀線",
+                                    "Yokosuka Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ty",
+                                    "#DA0042",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東横線",
+                                    "Minatomiral Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "kk",
+                                    "#00BFFF",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京急本線",
+                                    "Keikyu Main Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "so",
+                                    "#0071C1",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "相鉄本線",
+                                    "Sōtetsu Main Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "so",
+                                    "#0071C1",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "泉野線",
+                                    "Sōtetsu Izumino Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "yokohama",
+                                    "blueline",
+                                    "#005ba5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横浜市営地下鉄藍線",
+                                    "Yokohama Municipal Subway Blue Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jh",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横浜線",
+                                    "Yokohama Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "n2MXj9": {
+            "name": [
+                "桜木町",
+                "Sakuragichō"
+            ],
+            "secondaryName": false,
+            "num": "37",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "dm2B8G"
+            ],
+            "children": [
+                "51idIp"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "yb",
+                                    "#2F56A5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横浜市営地下鉄藍線",
+                                    "Yokohama Municipal Subway Blue Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "51idIp": {
+            "name": [
+                "関内",
+                "Kannai"
+            ],
+            "secondaryName": false,
+            "num": "38",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "n2MXj9"
+            ],
+            "children": [
+                "NvM1F7"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "yb",
+                                    "#2F56A5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横浜市営地下鉄藍線",
+                                    "Yokohama Municipal Subway Blue Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "NvM1F7": {
+            "name": [
+                "石川町",
+                "Ishikawachō"
+            ],
+            "secondaryName": false,
+            "num": "39",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "51idIp"
+            ],
+            "children": [
+                "Z_y9Kw"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jh",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横浜線",
+                                    "Yokohama Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "B6hM5g": {
+            "name": [
+                "北浦和",
+                "Kita-Urawa"
+            ],
+            "secondaryName": false,
+            "num": "04",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "HvjkB1"
+            ],
+            "children": [
+                "JWFhrH"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "-b2g5B": {
+            "name": [
+                "日暮里",
+                "Nippori"
+            ],
+            "secondaryName": false,
+            "num": "16",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "2krWzG"
+            ],
+            "children": [
+                "SnREPU"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jj",
+                                    "#1DAF7E",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "常磐線（快速）",
+                                    "Joban Line (Rapid)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ks",
+                                    "#005AAA",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京成本線",
+                                    "Keisei Main Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "nt",
+                                    "#D53A77",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日暮里・舎人ライナー",
+                                    "Nippori-toneri Liner"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "l",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "SnREPU": {
+            "name": [
+                "\t鶯谷",
+                "Uguisudani"
+            ],
+            "secondaryName": false,
+            "num": "17",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "-b2g5B"
+            ],
+            "children": [
+                "eex0RF"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "eex0RF": {
+            "name": [
+                ". 上野",
+                "...  Ueno"
+            ],
+            "secondaryName": false,
+            "num": "18",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "SnREPU"
+            ],
+            "children": [
+                "mWDIow"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#F18E41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "宇都宮線 · 高崎線",
+                                    "Utsunomiya Line·Takasaki Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jj",
+                                    "#1DAF7E",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "常磐線",
+                                    "Joban Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#F18E41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "上野東京ライン",
+                                    "Ueno-Tokyo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#ff9500",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#b5b5ac",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Hibiya Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ks",
+                                    "#005AAA",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京成本線",
+                                    "Keisei Main Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "京成上野",
+                            "Keisei-Ueno"
+                        ]
+                    },
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "l",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "mWDIow": {
+            "name": [
+                "御徒町",
+                "Okachimachi"
+            ],
+            "secondaryName": false,
+            "num": "19",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "eex0RF"
+            ],
+            "children": [
+                "nuPIYP"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "o",
+                                    "#ce045b",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営大江戸線",
+                                    "Toei Oedo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#ff9500",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Toei Oedo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#b5b5ac",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Toei Oedo Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "上野御徒町",
+                            "Ueno-okachimachi"
+                        ]
+                    },
+                    {
+                        "lines": [],
+                        "name": [
+                            "",
+                            ""
+                        ]
+                    }
+                ],
+                "tick_direc": "l",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "nuPIYP": {
+            "name": [
+                "\t秋葉原",
+                "Akihabara"
+            ],
+            "secondaryName": false,
+            "num": "20",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "mWDIow"
+            ],
+            "children": [
+                "Rf8ur9"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jb",
+                                    "#F2D01F",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "総武線（各駅停車）",
+                                    "Sōbu Line (Local)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#b5b5ac",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Hibiya Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "s",
+                                    "#b0bf1e",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営新宿線",
+                                    "Toei Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "mg",
+                                    "#009CD3",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "つくばエクスプレス ",
+                                    "Tsukuba Express"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Rf8ur9": {
+            "name": [
+                "神田",
+                "Kanda"
+            ],
+            "secondaryName": false,
+            "num": "21",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "nuPIYP"
+            ],
+            "children": [
+                "5cYW6h"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#ff9500",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jc",
+                                    "#DD6935",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央線",
+                                    "Chūō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "5cYW6h": {
+            "name": [
+                "東京 .",
+                "Tōkyō ..."
+            ],
+            "secondaryName": false,
+            "num": "22",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Rf8ur9"
+            ],
+            "children": [
+                "lOE1xx"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jt",
+                                    "#F0862B",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東海道線",
+                                    " Tōkaidō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#F18E41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "上野東京ライン",
+                                    "Ueno-Tōkyō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jc",
+                                    "#DD6935",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央線",
+                                    "Chūō Line (Rapid)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jo",
+                                    "#1069B4",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横須賀線 ·総武線（快速） ",
+                                    "Yokosuka LineSōbu Line (Rapid)·"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "je",
+                                    "#D01827",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京葉線",
+                                    "Keiyō Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#f62e36",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸ノ内線",
+                                    "Marunochi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "t",
+                                    "#009bbf",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東西線",
+                                    "Tozai Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "c",
+                                    "#00bb85",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "千代田線",
+                                    "Chiyoda Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "z",
+                                    "#8f76d6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "半蔵門線",
+                                    "Hanzōmon Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#006ab8",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営三田線",
+                                    "Toei Mita Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "大手町",
+                            "Ōtemachi"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lOE1xx": {
+            "name": [
+                "有楽町",
+                "Yūrakuchō"
+            ],
+            "secondaryName": false,
+            "num": "23",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "5cYW6h"
+            ],
+            "children": [
+                "XWaY5P"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#c1a470",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yūrakuchō Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "c",
+                                    "#00bb85",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "千代田線",
+                                    "Chiyoda Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#b5b5ac",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Hibiya Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#006ab8",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営三田線",
+                                    "Toei Mita Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸ノ内線",
+                                    "Marunochi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#f9a328",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "日比谷，銀座",
+                            "Hibiya, Ginza"
+                        ]
+                    },
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "l",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "XWaY5P": {
+            "name": [
+                "新橋",
+                "Shimbashi"
+            ],
+            "secondaryName": false,
+            "num": "24",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "lOE1xx"
+            ],
+            "children": [
+                "exuKD-"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jt",
+                                    "#F0862B",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東海道線",
+                                    "Tōkaidō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jo",
+                                    "#1069B4",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横須賀線",
+                                    "Yokosuka Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#ff9500",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "a",
+                                    "#ec6e65",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営浅草線",
+                                    "Toei Asakusa Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "u",
+                                    "#1662B8",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "臨海線",
+                                    "Rinkai Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "exuKD-": {
+            "name": [
+                "浜松町",
+                "Hamamatsuchō"
+            ],
+            "secondaryName": false,
+            "num": "25",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "XWaY5P"
+            ],
+            "children": [
+                "Vjcwaz"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "mo",
+                                    "#26326A",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東京モノレール羽田空港線",
+                                    "Tōkyo Monorail Haneda Airport Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "a",
+                                    "#dd4231",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営浅草線",
+                                    "Toei Asakusa Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "o",
+                                    "#ce1c64",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営大江戸線",
+                                    "Toei Oedo Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "大門",
+                            "Daimon"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Vjcwaz": {
+            "name": [
+                "田町",
+                "Tamachi"
+            ],
+            "secondaryName": false,
+            "num": "26",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "exuKD-"
+            ],
+            "children": [
+                "ZLDFmm"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#0068a5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営三田線",
+                                    "Toei Mita Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "a",
+                                    "#dd4231",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営浅草線",
+                                    "Toei Asakusa Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "三田",
+                            "Mita"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "JWFhrH": {
+            "name": [
+                "\t浦和",
+                "Urawa"
+            ],
+            "secondaryName": false,
+            "num": "05",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "B6hM5g"
+            ],
+            "children": [
+                "z-8L8W"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#f68b1f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "宇都宮線 · 高崎線",
+                                    "Utsunomiya Line·Takasaki Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿線",
+                                    "Shōnan-Shinjuku Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "z-8L8W": {
+            "name": [
+                "南浦和",
+                "Minami-Urawa"
+            ],
+            "secondaryName": false,
+            "num": "06",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "JWFhrH"
+            ],
+            "children": [
+                "ZJ2DcG"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jm",
+                                    "#EB5A28",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "武蔵野線",
+                                    "Musashino Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "ZJ2DcG": {
+            "name": [
+                "蕨",
+                "Warabi"
+            ],
+            "secondaryName": false,
+            "num": "07",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "z-8L8W"
+            ],
+            "children": [
+                "zohOfN"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "zohOfN": {
+            "name": [
+                "西川口",
+                "Nishi-Kawaguchi"
+            ],
+            "secondaryName": false,
+            "num": "08",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ZJ2DcG"
+            ],
+            "children": [
+                "7kovNF"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "7kovNF": {
+            "name": [
+                "川口",
+                "Kawaguchi"
+            ],
+            "secondaryName": false,
+            "num": "09",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "zohOfN"
+            ],
+            "children": [
+                "P-Ty2i"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "P-Ty2i": {
+            "name": [
+                "赤羽",
+                "Akabane"
+            ],
+            "secondaryName": false,
+            "num": "10",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "7kovNF"
+            ],
+            "children": [
+                "cj6Jl1"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#F18E41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "宇都宮線 · 高崎線",
+                                    "Utsunomiya Line·Takasaki Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿ライン",
+                                    "Shōnan-Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ja",
+                                    "#14A676",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "埼京線",
+                                    " Saikyō Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "cj6Jl1": {
+            "name": [
+                "東十条",
+                "Higashi-Jūjō"
+            ],
+            "secondaryName": false,
+            "num": "11",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "P-Ty2i"
+            ],
+            "children": [
+                "nug0uR"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "nug0uR": {
+            "name": [
+                "王子",
+                "Ōji"
+            ],
+            "secondaryName": false,
+            "num": "12",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "cj6Jl1"
+            ],
+            "children": [
+                "-b-IT0"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "n",
+                                    "#02b69b",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東京メトロ南北線 ",
+                                    "Tokyo Metro Namboku Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "-b-IT0": {
+            "name": [
+                "上中里",
+                "Kami-Nakazato"
+            ],
+            "secondaryName": false,
+            "num": "13",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "nug0uR"
+            ],
+            "children": [
+                "gROTTD"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "gROTTD": {
+            "name": [
+                "\t田端",
+                "Tabata"
+            ],
+            "secondaryName": false,
+            "num": "14",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "-b-IT0"
+            ],
+            "children": [
+                "2krWzG"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "2krWzG": {
+            "name": [
+                "西日暮里\t",
+                "Nishi-Nippori"
+            ],
+            "secondaryName": false,
+            "num": "15",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "gROTTD"
+            ],
+            "children": [
+                "-b2g5B"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jy",
+                                    "#B1CB39",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "nt",
+                                    "#D53A77",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日暮里・舎人ライナー",
+                                    "Nippori-toneri Liner"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "V8nrMr": {
+            "name": [
+                "大宮",
+                "Ōmiya"
+            ],
+            "secondaryName": false,
+            "num": "01",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "NPIcPP"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#F18E41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "宇都宮線 · 高崎線",
+                                    "Utsunomiya Line·Takasaki Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿ライン",
+                                    "Shōnan-Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ja",
+                                    "#14A676",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "埼京線",
+                                    "Saikyō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "td",
+                                    "#40B4E5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東武アーバンパークライン",
+                                    "Tobu Urban Park Line Ina Line (New Shuttle)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jm",
+                                    "#EB5A28",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "武藏野線",
+                                    "Musashino Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "NPIcPP": {
+            "name": [
+                "埼玉新都心",
+                "Saitama-Shintoshin"
+            ],
+            "secondaryName": false,
+            "num": "02",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "V8nrMr"
+            ],
+            "children": [
+                "HvjkB1"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#F18E41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "宇都宮線 · 高崎線",
+                                    "Utsunomiya Line·Takasaki Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "HvjkB1": {
+            "name": [
+                "与野",
+                "Yono"
+            ],
+            "secondaryName": false,
+            "num": "03",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "NPIcPP"
+            ],
+            "children": [
+                "B6hM5g"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": false,
+        "isFlip": false
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "JK",
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "notesGZMTR": [],
+    "direction_gz_x": 39,
+    "direction_gz_y": 83,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    }
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of East Japan Railway Company on behalf of Takagi-Misae.
This should fix #647

**Review links**
[JREAST/JK.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F89ec2bfd95828de271dc4b83401e28100ec7bca2%2Fpublic%2Fresources%2Ftemplates%2FJREAST%2FJK.json)