### PR TITLE
Resources: New templates of Nanjing Metro

### DIFF
--- a/public/resources/templates/njmetro/00config.json
+++ b/public/resources/templates/njmetro/00config.json
@@ -98,5 +98,14 @@
             "zh-Hant": "S7號線"
         },
         "uploadBy": "njmetro-jxzb"
+    },
+    {
+        "filename": "S9",
+        "name": {
+            "en": "S9",
+            "zh-Hans": "S9",
+            "zh-Hant": "S9"
+        },
+        "uploadBy": "Z-S-TTH"
     }
 ]

--- a/public/resources/templates/njmetro/S9.json
+++ b/public/resources/templates/njmetro/S9.json
@@ -1,0 +1,194 @@
+{
+    "svgWidth": {
+        "destination": 1500,
+        "runin": 1500,
+        "railmap": 1500,
+        "indoor": 1500
+    },
+    "svg_height": 400,
+    "style": "shmetro",
+    "y_pc": 50,
+    "padding": 10,
+    "branchSpacingPct": 33,
+    "direction": "r",
+    "platform_num": "1",
+    "theme": [
+        "nanjing",
+        "s9",
+        "#f1b434",
+        "#fff"
+    ],
+    "line_name": [
+        "S9号线",
+        "Line S9"
+    ],
+    "current_stn_idx": "stn_Rj5CnqOAkT",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "stn_Rj5CnqOAkT"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "stn_APBWHoo2Pd"
+            ],
+            "children": [],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "stn_APBWHoo2Pd": {
+            "name": [
+                "高淳",
+                ""
+            ],
+            "secondaryName": false,
+            "num": "2",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "stn_Rj5CnqOAkT"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "stn_Rj5CnqOAkT": {
+            "name": [
+                "翔宇路南",
+                ""
+            ],
+            "secondaryName": false,
+            "num": "1",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "stn_APBWHoo2Pd"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "nanjing",
+                                    "s1",
+                                    "#00b2a9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "s1",
+                                    "s1"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": true
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "",
+    "psd_num": "1",
+    "info_panel_type": "sh",
+    "notesGZMTR": [],
+    "direction_gz_x": 40,
+    "direction_gz_y": 70,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 0,
+        "bottom_factor": 1
+    }
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Nanjing Metro on behalf of Z-S-TTH.
This should fix #632

**Review links**
[njmetro/S9.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fef496942c53ce49ae455905b4d2c701ac73666d8%2Fpublic%2Fresources%2Ftemplates%2Fnjmetro%2FS9.json)