### PR TITLE
Resources: New templates of East Japan Railway

### DIFF
--- a/public/resources/templates/JREAST/00config.json
+++ b/public/resources/templates/JREAST/00config.json
@@ -8,5 +8,15 @@
             "ja": "京浜東北線"
         },
         "uploadBy": "Takagi-Misae"
+    },
+    {
+        "filename": "JY",
+        "name": {
+            "en": "Yamanote Line",
+            "zh-Hans": "山手线",
+            "zh-Hant": "山手線",
+            "ja": "山手線"
+        },
+        "uploadBy": "Takagi-Misae"
     }
 ]

--- a/public/resources/templates/JREAST/JY.json
+++ b/public/resources/templates/JREAST/JY.json
@@ -1,0 +1,2675 @@
+{
+    "svgWidth": {
+        "destination": 1500,
+        "runin": 1200,
+        "railmap": 13000,
+        "indoor": 20000
+    },
+    "svg_height": 500,
+    "style": "mtr",
+    "y_pc": 30,
+    "padding": 4,
+    "branchSpacingPct": 33,
+    "direction": "r",
+    "platform_num": 1,
+    "theme": [
+        "other",
+        "other",
+        "#7bab4f",
+        "#fff"
+    ],
+    "line_name": [
+        "山手線",
+        "Yamanote Line"
+    ],
+    "current_stn_idx": "U8gVcj",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "secondaryName": false,
+            "num": 0,
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "U8gVcj"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "secondaryName": false,
+            "num": 0,
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "cqbVO1"
+            ],
+            "children": [],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "ZLDFmm": {
+            "name": [
+                "高輪ゲートウェイ",
+                "Takanawa Gateway"
+            ],
+            "secondaryName": false,
+            "num": "26",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Vjcwaz"
+            ],
+            "children": [
+                "cqbVO1"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tōhokū Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "a",
+                                    "#dd4231",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営浅草線",
+                                    "Toei Asakusa Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "kk",
+                                    "#00BFFF",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京急本線",
+                                    "Keikyu Main Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "泉岳寺",
+                            "Sengakuji"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "cqbVO1": {
+            "name": [
+                "品川",
+                "Shinagawa"
+            ],
+            "secondaryName": false,
+            "num": "25",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ZLDFmm"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線 ",
+                                    "Keihin-Tōhoku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jo",
+                                    "#1069B4",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横須賀線",
+                                    "Yokosuka Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jt",
+                                    "#F0862B",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東海道線",
+                                    "Tōkaidō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "kk",
+                                    "#00BFFF",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京急本線",
+                                    "Keikyū Main Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#f68b1f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "上野東京線",
+                                    "Ueno-Tokyo Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "-b2g5B": {
+            "name": [
+                "日暮里",
+                "Nippori"
+            ],
+            "secondaryName": false,
+            "num": "07",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "2krWzG"
+            ],
+            "children": [
+                "SnREPU"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jj",
+                                    "#1DAF7E",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "常磐線（快速）",
+                                    "Joban Line (Rapid)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ks",
+                                    "#005AAA",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京成本線",
+                                    "Keisei Main Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "nt",
+                                    "#D53A77",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日暮里・舎人ライナー",
+                                    "Nippori-toneri Liner"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#f68b1f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "上野東京線",
+                                    "Ueno-Tokyo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tōhoku Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "l",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "SnREPU": {
+            "name": [
+                "\t鶯谷",
+                "Uguisudani"
+            ],
+            "secondaryName": false,
+            "num": "06",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "-b2g5B"
+            ],
+            "children": [
+                "eex0RF"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tōhoku Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "eex0RF": {
+            "name": [
+                "上野",
+                "Ueno"
+            ],
+            "secondaryName": false,
+            "num": "05",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "SnREPU"
+            ],
+            "children": [
+                "mWDIow"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tōhoku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#F18E41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "宇都宮線 · 高崎線",
+                                    "Utsunomiya Line·Takasaki Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jj",
+                                    "#1DAF7E",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "常磐線",
+                                    "Joban Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#F18E41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "上野東京線",
+                                    "Ueno-Tokyo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#ff9500",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#b5b5ac",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Hibiya Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ks",
+                                    "#005AAA",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京成本線",
+                                    "Keisei Main Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "京成上野",
+                            "Keisei-Ueno"
+                        ]
+                    },
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "l",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "mWDIow": {
+            "name": [
+                "御徒町",
+                "Okachimachi"
+            ],
+            "secondaryName": false,
+            "num": "04",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "eex0RF"
+            ],
+            "children": [
+                "nuPIYP"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tōhoku Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "o",
+                                    "#ce045b",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営大江戸線",
+                                    "Toei Oedo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#ff9500",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Toei Oedo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#b5b5ac",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Toei Oedo Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "上野御徒町",
+                            "Ueno-okachimachi"
+                        ]
+                    },
+                    {
+                        "lines": [],
+                        "name": [
+                            "",
+                            ""
+                        ]
+                    }
+                ],
+                "tick_direc": "l",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "nuPIYP": {
+            "name": [
+                "\t秋葉原",
+                "Akihabara"
+            ],
+            "secondaryName": false,
+            "num": "03",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "mWDIow"
+            ],
+            "children": [
+                "Rf8ur9"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tōhoku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jb",
+                                    "#F2D01F",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "総武線（各駅停車）",
+                                    "Sōbu Line (Local)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#b5b5ac",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Hibiya Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "s",
+                                    "#b0bf1e",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営新宿線",
+                                    "Toei Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "mg",
+                                    "#009CD3",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "つくばエクスプレス ",
+                                    "Tsukuba Express"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Rf8ur9": {
+            "name": [
+                "神田",
+                "Kanda"
+            ],
+            "secondaryName": false,
+            "num": "02",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "nuPIYP"
+            ],
+            "children": [
+                "5cYW6h"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#ff9500",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jc",
+                                    "#DD6935",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央本線",
+                                    "Chūō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tōhoku Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "5cYW6h": {
+            "name": [
+                "東京",
+                "Tōkyō"
+            ],
+            "secondaryName": false,
+            "num": "01",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Rf8ur9"
+            ],
+            "children": [
+                "lOE1xx"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tōhokū Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jt",
+                                    "#F0862B",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東海道線",
+                                    " Tōkaidō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#F18E41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "上野東京線",
+                                    "Ueno-Tokyo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jc",
+                                    "#DD6935",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央線",
+                                    "Chūō Line (Rapid)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jo",
+                                    "#1069B4",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横須賀線 ·総武線（快速） ",
+                                    "Yokosuka LineSōbu Line (Rapid)·"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "je",
+                                    "#D01827",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京葉線",
+                                    "Keiyō Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#f62e36",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸ノ内線",
+                                    "Marunochi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "t",
+                                    "#009bbf",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東西線",
+                                    "Tozai Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "c",
+                                    "#00bb85",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "千代田線",
+                                    "Chiyoda Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "z",
+                                    "#8f76d6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "半蔵門線",
+                                    "Hanzōmon Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#006ab8",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営三田線",
+                                    "Toei Mita Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "大手町",
+                            "Ōtemachi"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lOE1xx": {
+            "name": [
+                "有楽町",
+                "Yūrakuchō"
+            ],
+            "secondaryName": false,
+            "num": "30",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "5cYW6h"
+            ],
+            "children": [
+                "XWaY5P"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tōhokū Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#c1a470",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yūrakuchō Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "c",
+                                    "#00bb85",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "千代田線",
+                                    "Chiyoda Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#b5b5ac",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Hibiya Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#006ab8",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営三田線",
+                                    "Toei Mita Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸ノ内線",
+                                    "Marunochi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#f9a328",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "日比谷/銀座",
+                            "Hibiya/Ginza"
+                        ]
+                    },
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "l",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "XWaY5P": {
+            "name": [
+                "新橋",
+                "Shimbashi"
+            ],
+            "secondaryName": false,
+            "num": "29",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "lOE1xx"
+            ],
+            "children": [
+                "exuKD-"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jt",
+                                    "#F0862B",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東海道線",
+                                    "Tōkaidō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tōhoku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jo",
+                                    "#1069B4",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "横須賀線",
+                                    "Yokosuka Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#ff9500",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "a",
+                                    "#ec6e65",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営浅草線",
+                                    "Toei Asakusa Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "u",
+                                    "#1662B8",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "臨海線",
+                                    "Rinkai Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#f68b1f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "上野東京線",
+                                    "Ueno-Tokyo Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "exuKD-": {
+            "name": [
+                "浜松町",
+                "Hamamatsuchō"
+            ],
+            "secondaryName": false,
+            "num": "28",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "XWaY5P"
+            ],
+            "children": [
+                "Vjcwaz"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tōhokū Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "mo",
+                                    "#26326A",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東京モノレール羽田空港線",
+                                    "Tōkyo Monorail Haneda Airport Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "a",
+                                    "#dd4231",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営浅草線",
+                                    "Toei Asakusa Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "o",
+                                    "#ce1c64",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営大江戸線",
+                                    "Toei Oedo Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "大門",
+                            "Daimon"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Vjcwaz": {
+            "name": [
+                "田町",
+                "Tamachi"
+            ],
+            "secondaryName": false,
+            "num": "27",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "exuKD-"
+            ],
+            "children": [
+                "ZLDFmm"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tōhoku Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#0068a5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営三田線",
+                                    "Toei Mita Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "a",
+                                    "#dd4231",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営浅草線",
+                                    "Toei Asakusa Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "三田",
+                            "Mita"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "gROTTD": {
+            "name": [
+                "\t田端",
+                "Tabata"
+            ],
+            "secondaryName": false,
+            "num": "09",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "wAlaiw"
+            ],
+            "children": [
+                "2krWzG"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京濱東北線",
+                                    "Keihin-Tōhoku Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "2krWzG": {
+            "name": [
+                "西日暮里\t",
+                "Nishi-Nippori"
+            ],
+            "secondaryName": false,
+            "num": "08",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "gROTTD"
+            ],
+            "children": [
+                "-b2g5B"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    " Keihin-Tōhoku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "nt",
+                                    "#D53A77",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日暮里・舎人ライナー",
+                                    "Nippori-toneri Liner"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "c",
+                                    "#1bb267",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "千代田線",
+                                    "Chiyoda Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "wAlaiw": {
+            "name": [
+                "駒込",
+                "Komagome"
+            ],
+            "secondaryName": false,
+            "num": "10",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "wIEGhw"
+            ],
+            "children": [
+                "gROTTD"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "n",
+                                    "#02b69b",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "南北線",
+                                    "Namboku Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "wIEGhw": {
+            "name": [
+                "巢鴨",
+                "Sugamo"
+            ],
+            "secondaryName": false,
+            "num": "11",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "JKIVYQ"
+            ],
+            "children": [
+                "wAlaiw"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#0068a5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営三田線",
+                                    "Toei Mita Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "JKIVYQ": {
+            "name": [
+                "大塚",
+                "Otsuka"
+            ],
+            "secondaryName": false,
+            "num": "12",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "v5hTbZ"
+            ],
+            "children": [
+                "wIEGhw"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "sa",
+                                    "#d75b80",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "荒川線",
+                                    "Arakawa Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "v5hTbZ": {
+            "name": [
+                "池袋",
+                "Ikebukuro"
+            ],
+            "secondaryName": false,
+            "num": "13",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "mjOGec"
+            ],
+            "children": [
+                "JKIVYQ"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ja",
+                                    "#0ab38d",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "埼京線",
+                                    "Saikyō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿線",
+                                    "Shōnan-Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "tj",
+                                    "#00428E",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東上本線",
+                                    "Tōbu Tōjō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "si",
+                                    "#EF7A00",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "西武池袋線",
+                                    "Seibu Ikebukuro Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸ノ内線",
+                                    "Marunouchi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yūrakuchō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "f",
+                                    "#9c5e31",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "副都心線",
+                                    "Fukutoshin Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "mjOGec": {
+            "name": [
+                "目白",
+                "Mejiro"
+            ],
+            "secondaryName": false,
+            "num": "14",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "c82ZxD"
+            ],
+            "children": [
+                "v5hTbZ"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "c82ZxD": {
+            "name": [
+                "高田馬場",
+                "Takadanobaba"
+            ],
+            "secondaryName": false,
+            "num": "15",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "8smBC6"
+            ],
+            "children": [
+                "mjOGec"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ss",
+                                    "#00A6BF",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "西武新宿線",
+                                    "Seibu Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "t",
+                                    "#00a4db",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東西線",
+                                    "Tōzai Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "f",
+                                    "#9c5e31",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "副都心線",
+                                    "Fukutoshin Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "西早稻田",
+                            "Nishi-Waseda"
+                        ]
+                    },
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "8smBC6": {
+            "name": [
+                "新大久保",
+                "Shin-Ōkubo"
+            ],
+            "secondaryName": false,
+            "num": "16",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "SpXg6E"
+            ],
+            "children": [
+                "c82ZxD"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "SpXg6E": {
+            "name": [
+                "新宿",
+                "Shinjuku"
+            ],
+            "secondaryName": false,
+            "num": "17",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "I07Jvh"
+            ],
+            "children": [
+                "8smBC6"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ja",
+                                    "#0ab38d",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "埼京線",
+                                    "Saikyō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿線",
+                                    "Shōnan-Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jc",
+                                    "#f15921",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央線（快速）",
+                                    "Chūō Line (Rapid)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#fed304",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央總武線（各駅停車）",
+                                    "Chūō-Sōbu Line (Local)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ko",
+                                    "#D5007F",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京王線",
+                                    "Keiō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "oh",
+                                    "#0085CE",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "小田原線",
+                                    "Odawara Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸ノ内線",
+                                    "Marunouchi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "s",
+                                    "#abba41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営新宿線",
+                                    "Toei Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "o",
+                                    "#ce1c64",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営大江戶線",
+                                    "Toei Ōedo Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ss",
+                                    "#00A6BF",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "西武新宿線",
+                                    "Seibu Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "o",
+                                    "#ce1c64",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営大江戶線",
+                                    "Toei Ōedo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "f",
+                                    "#9c5e31",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "副都心線",
+                                    "Fukutoshin Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "s",
+                                    "#abba41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営新宿線",
+                                    "Toei Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ko",
+                                    "#D5007F",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京王線",
+                                    "Keiō Shin Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "西武新宿，新宿西口，新宿三丁目，都廳前，新線新宿站",
+                            "Seibu Shinjuku, Shinjuku-Nishiguchi, Shinjuku-Sanchōme, Tochōmae, Shinsen-Shinjuku"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "I07Jvh": {
+            "name": [
+                "代々木",
+                "Yoyogi"
+            ],
+            "secondaryName": false,
+            "num": "18",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "iVCKsC"
+            ],
+            "children": [
+                "SpXg6E"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#fed304",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央總武線（各駅停車）",
+                                    "Chūō-Sōbu Line (Local)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "o",
+                                    "#ce1c64",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営大江戸線",
+                                    "Toei Oedo Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "iVCKsC": {
+            "name": [
+                "原宿",
+                "Harajuku"
+            ],
+            "secondaryName": false,
+            "num": "19",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "_aux20"
+            ],
+            "children": [
+                "I07Jvh"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "c",
+                                    "#1bb267",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "千代田線",
+                                    "Chiyoda Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "f",
+                                    "#9c5e31",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "副都心線",
+                                    "Fukutoshin Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "明治神宮前",
+                            "Meiji-Jingūmae"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "_aux20": {
+            "name": [
+                "渋谷",
+                "Shibuya"
+            ],
+            "secondaryName": false,
+            "num": "20",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Efn6fj"
+            ],
+            "children": [
+                "iVCKsC"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ja",
+                                    "#0ab38d",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "埼京線",
+                                    "Saikyō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿線",
+                                    "Shōnan-Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ty",
+                                    "#DA0042",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東急東橫線",
+                                    "Tōyoko Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "dt",
+                                    "#00AA8D",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東急田園都市線",
+                                    "Den'en-toshi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "f",
+                                    "#9c5e31",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "副都心線",
+                                    "Fukutoshin Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#f9a328",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "z",
+                                    "#8c7dba",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "半藏門線",
+                                    "Hanzomon Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Efn6fj": {
+            "name": [
+                "恵比寿",
+                "Ebisu"
+            ],
+            "secondaryName": false,
+            "num": "21",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "vAz3zC"
+            ],
+            "children": [
+                "_aux20"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ja",
+                                    "#0ab38d",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "埼京線",
+                                    "Saikyō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿線",
+                                    "Shōnan-Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#c7beb3",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Hibiya Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "vAz3zC": {
+            "name": [
+                "目黑",
+                "Meguro"
+            ],
+            "secondaryName": false,
+            "num": "22",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "IMqRuk"
+            ],
+            "children": [
+                "Efn6fj"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "mg",
+                                    "#009CD3",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東急目黑線",
+                                    "Meguro Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "n",
+                                    "#02b69b",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "南北線",
+                                    "Namboku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#0068a5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "三田線",
+                                    "Mita Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "IMqRuk": {
+            "name": [
+                "五反田",
+                "Gotanda"
+            ],
+            "secondaryName": false,
+            "num": "23",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "U8gVcj"
+            ],
+            "children": [
+                "vAz3zC"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ik",
+                                    "#EE86A8",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東急池上線",
+                                    "Ikegami Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "a",
+                                    "#dd4231",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営淺草線",
+                                    "Toei Asakusa Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "U8gVcj": {
+            "name": [
+                "大崎",
+                "Osaki"
+            ],
+            "secondaryName": false,
+            "num": "24",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "IMqRuk"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "r",
+                                    "#00418e",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "臨海線",
+                                    "Rinkai Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿線",
+                                    "Shōnan-Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ja",
+                                    "#0ab38d",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "埼京線",
+                                    "Saikyō Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": false,
+        "isFlip": true
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "JY",
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "notesGZMTR": [],
+    "direction_gz_x": 39,
+    "direction_gz_y": 83,
+    "coline": {},
+    "loop": true,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 0,
+        "bottom_factor": 1
+    }
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of East Japan Railway on behalf of Takagi-Misae.
This should fix #685

**Review links**
[JREAST/JY.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F1d4ae7d2677befe8286bb2b0a01d50a6fd3cd544%2Fpublic%2Fresources%2Ftemplates%2FJREAST%2FJY.json)