### PR TITLE
Resources: New templates of Tokyo Metro

### DIFF
--- a/public/resources/other-company-config.json
+++ b/public/resources/other-company-config.json
@@ -439,6 +439,14 @@
         }
     },
     {
+        "id": "tyometro",
+        "name": {
+            "en": "Tokyo Metro",
+            "zh-Hans": "东京地下铁",
+            "zh-Hant": "東京地下鐵"
+        }
+    },
+    {
         "id": "urumqimetro",
         "name": {
             "en": "Urumqi Metro",

--- a/public/resources/templates/tyometro/00config.json
+++ b/public/resources/templates/tyometro/00config.json
@@ -1,0 +1,12 @@
+[
+    {
+        "filename": "F",
+        "name": {
+            "en": "Fukutoshin Line",
+            "zh-Hans": "副都心线",
+            "zh-Hant": "副都心線",
+            "ja": "副都心線"
+        },
+        "uploadBy": "Takagi-Misae"
+    }
+]

--- a/public/resources/templates/tyometro/F.json
+++ b/public/resources/templates/tyometro/F.json
@@ -1,0 +1,1085 @@
+{
+    "svgWidth": {
+        "destination": 1500,
+        "runin": 1200,
+        "railmap": 3000,
+        "indoor": 5000
+    },
+    "svg_height": 700,
+    "style": "gzmtr",
+    "y_pc": 50,
+    "padding": 10,
+    "branchSpacingPct": 33,
+    "direction": "r",
+    "platform_num": "1",
+    "theme": [
+        "tokyo",
+        "f",
+        "#9c5e31",
+        "#fff"
+    ],
+    "line_name": [
+        "副都心線",
+        "Fukutoshin Line"
+    ],
+    "current_stn_idx": "rms7Gu",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "rms7Gu"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "rms7Gu": {
+            "name": [
+                "和光市",
+                "Wakoshi"
+            ],
+            "secondaryName": false,
+            "num": "01",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "gJuix2"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "tj",
+                                    "#00428E",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東武東上線",
+                                    "Tobu Tojo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yurakucho Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "gJuix2": {
+            "name": [
+                "地下鉄成増",
+                "Chikatetsu-Narimasu"
+            ],
+            "secondaryName": false,
+            "num": "02",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "rms7Gu"
+            ],
+            "children": [
+                "RvZ37Y"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yurakucho Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "YG0d5e"
+            ],
+            "children": [],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "RvZ37Y": {
+            "name": [
+                "地下鉄赤塚",
+                "Chikatetsu-Akatsuka"
+            ],
+            "secondaryName": false,
+            "num": "03",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "gJuix2"
+            ],
+            "children": [
+                "NZKh1T"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yurakucho Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "NZKh1T": {
+            "name": [
+                "平和台",
+                "Heiwadai"
+            ],
+            "secondaryName": false,
+            "num": "04",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "RvZ37Y"
+            ],
+            "children": [
+                "2R0hSm"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yurakucho Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "2R0hSm": {
+            "name": [
+                "氷川台",
+                "Hikawadai"
+            ],
+            "secondaryName": false,
+            "num": "05",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "NZKh1T"
+            ],
+            "children": [
+                "w6DUAQ"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yurakucho Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "w6DUAQ": {
+            "name": [
+                "小竹向原",
+                "Kotake-Mukaihara "
+            ],
+            "secondaryName": false,
+            "num": "06",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "2R0hSm"
+            ],
+            "children": [
+                "x1ppMs"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "si",
+                                    "#EF7A00",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "西武有楽町線",
+                                    "Seibu Yurakucho Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yurakucho Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "x1ppMs": {
+            "name": [
+                "千川",
+                "Senkawa"
+            ],
+            "secondaryName": false,
+            "num": "07",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "w6DUAQ"
+            ],
+            "children": [
+                "rXTx2E"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yurakucho Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "rXTx2E": {
+            "name": [
+                "要町",
+                "Kanamecho "
+            ],
+            "secondaryName": false,
+            "num": "08",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "x1ppMs"
+            ],
+            "children": [
+                "MHqwWx"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yurakucho Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "MHqwWx": {
+            "name": [
+                "池袋",
+                "Ikebukuro"
+            ],
+            "secondaryName": false,
+            "num": "09",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "rXTx2E"
+            ],
+            "children": [
+                "-gJ_dh"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yurakucho Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸ノ内線",
+                                    "Marunouchi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#7bab4f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ja",
+                                    "#0ab38d",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "埼京線",
+                                    "Keikyo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿線",
+                                    "Shonan-Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "tj",
+                                    "#00428E",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東武東上線",
+                                    "Tobu Toju Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "si",
+                                    "#EF7A00",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "西武池袋線",
+                                    "Seibu Ikebukuro Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "-gJ_dh": {
+            "name": [
+                "雑司が谷",
+                "Zoshigaya"
+            ],
+            "secondaryName": false,
+            "num": "10",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "MHqwWx"
+            ],
+            "children": [
+                "kb8cl2"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "kb8cl2": {
+            "name": [
+                "西早稲田",
+                "Nishi-Waseda"
+            ],
+            "secondaryName": false,
+            "num": "11",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "-gJ_dh"
+            ],
+            "children": [
+                "t58xT5"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "t",
+                                    "#00a4db",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東西線",
+                                    "Tozai Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ss",
+                                    "#00A6BF",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "西武新宿線",
+                                    "Seibu Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#7bab4f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線線",
+                                    "Yamanote Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "高田馬場",
+                            "Takadanobaba"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "t58xT5": {
+            "name": [
+                "東新宿",
+                "Higashi-Shinjuku "
+            ],
+            "secondaryName": false,
+            "num": "12",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "kb8cl2"
+            ],
+            "children": [
+                "kfhmqV"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "o",
+                                    "#ce1c64",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営大江戸線",
+                                    "Toei Oedo Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "kfhmqV": {
+            "name": [
+                "新宿三丁目",
+                "Shinjuku-Sanchome"
+            ],
+            "secondaryName": false,
+            "num": "13",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "t58xT5"
+            ],
+            "children": [
+                "RDRZ0z"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸ノ内線",
+                                    "Marunouchi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "s",
+                                    "#abba41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営新宿線",
+                                    "Toei Shinjuku Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "RDRZ0z": {
+            "name": [
+                "北参道",
+                "Kita-Sando"
+            ],
+            "secondaryName": false,
+            "num": "14",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "kfhmqV"
+            ],
+            "children": [
+                "tdO8kZ"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "tdO8kZ": {
+            "name": [
+                "明治神宮前",
+                "Meiji-Jingumae "
+            ],
+            "secondaryName": false,
+            "num": "15",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "RDRZ0z"
+            ],
+            "children": [
+                "YG0d5e"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "c",
+                                    "#1bb267",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "千代田線",
+                                    "Chiyoda Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#7bab4f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "原宿",
+                            "Harajuku"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "YG0d5e": {
+            "name": [
+                "渋谷",
+                "Shibuya"
+            ],
+            "secondaryName": false,
+            "num": "16",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "tdO8kZ"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "z",
+                                    "#8c7dba",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "半藏門線",
+                                    "Hanzomon Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#f9a328",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#7bab4f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ja",
+                                    "#0ab38d",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "埼京線",
+                                    "Keikyo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿線",
+                                    "Shonan-Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "in",
+                                    "#103675",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京王井之頭線",
+                                    "Keio Inokashira Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ty",
+                                    "#DA0042",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東急東橫頭線",
+                                    "Tokyu Toyoko Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "dt",
+                                    "#00AA8D",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東急田園都市線",
+                                    "Tokyu Den‘en-Toshi Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": false
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "F",
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "notesGZMTR": [],
+    "direction_gz_x": 40,
+    "direction_gz_y": 70,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    }
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Tokyo Metro on behalf of Takagi-Misae.
This should fix #695

**Review links**
[tyometro/F.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F4a65862b0816c4c42a59db4bdc12ef52279846ff%2Fpublic%2Fresources%2Ftemplates%2Ftyometro%2FF.json)