### PR TITLE
Resources: New templates of Xi'an Metro

### DIFF
--- a/public/resources/templates/xianrail/xa5.json
+++ b/public/resources/templates/xianrail/xa5.json
@@ -741,18 +741,12 @@
             "transfer": {
                 "groups": [
                     {
-                        "lines": []
-                    },
-                    {
-                        "lines": []
-                    },
-                    {
                         "lines": [
                             {
                                 "theme": [
                                     "other",
                                     "other",
-                                    "#72217c",
+                                    "#72217C",
                                     "#fff"
                                 ],
                                 "name": [
@@ -761,6 +755,12 @@
                                 ]
                             }
                         ]
+                    },
+                    {
+                        "lines": []
+                    },
+                    {
+                        "lines": []
                     }
                 ],
                 "tick_direc": "r",

--- a/public/resources/templates/xianrail/xaxh.json
+++ b/public/resources/templates/xianrail/xaxh.json
@@ -79,12 +79,6 @@
             "transfer": {
                 "groups": [
                     {
-                        "lines": []
-                    },
-                    {
-                        "lines": []
-                    },
-                    {
                         "lines": [
                             {
                                 "theme": [
@@ -99,6 +93,12 @@
                                 ]
                             }
                         ]
+                    },
+                    {
+                        "lines": []
+                    },
+                    {
+                        "lines": []
                     }
                 ],
                 "tick_direc": "r",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Xi'an Metro on behalf of Wuyirende.
This should fix #705

**Review links**
[xianrail/xa5.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fc69767907127cf4c383e9454729e6c4a05eae381%2Fpublic%2Fresources%2Ftemplates%2Fxianrail%2Fxa5.json)
[xianrail/xaxh.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fc69767907127cf4c383e9454729e6c4a05eae381%2Fpublic%2Fresources%2Ftemplates%2Fxianrail%2Fxaxh.json)