### PR TITLE
Resources: New templates of London Tube

### DIFF
--- a/public/resources/other-company-config.json
+++ b/public/resources/other-company-config.json
@@ -209,6 +209,14 @@
         }
     },
     {
+        "id": "londontransport",
+        "name": {
+            "en": "London Tube",
+            "zh-Hans": "伦敦地铁",
+            "zh-Hant": "倫敦地鐵"
+        }
+    },
+    {
         "id": "luoyangsubway",
         "name": {
             "en": "Luoyang Subway",

--- a/public/resources/templates/londontransport/00config.json
+++ b/public/resources/templates/londontransport/00config.json
@@ -1,0 +1,11 @@
+[
+    {
+        "filename": "piccadilly",
+        "name": {
+            "en": "Piccadilly Line(Terminal 4 Feeder Lines Are Not Included)",
+            "zh-Hans": "皮卡迪利线(不包括T4支线)",
+            "zh-Hant": "皮卡迪利線(不包括T4支線)"
+        },
+        "uploadBy": "UnnamedKiana"
+    }
+]

--- a/public/resources/templates/londontransport/piccadilly.json
+++ b/public/resources/templates/londontransport/piccadilly.json
@@ -1,0 +1,2239 @@
+{
+    "svgWidth": {
+        "destination": 6000,
+        "runin": 6000,
+        "railmap": 6000,
+        "indoor": 6000
+    },
+    "svg_height": 650,
+    "style": "shmetro",
+    "y_pc": 50,
+    "padding": 2,
+    "branchSpacingPct": 43,
+    "direction": "r",
+    "platform_num": "5",
+    "theme": [
+        "london",
+        "piccadily",
+        "#0019A8",
+        "#fff"
+    ],
+    "line_name": [
+        "皮卡迪利线",
+        "Picadilly Line"
+    ],
+    "current_stn_idx": "GRePRY",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "lY888e"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lY888e": {
+            "name": [
+                "卡克福斯特斯",
+                "Cockfosters"
+            ],
+            "secondaryName": false,
+            "num": "01",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "eRk1KM"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "eRk1KM": {
+            "name": [
+                "橡木林",
+                "Oakwood"
+            ],
+            "secondaryName": false,
+            "num": "02",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "lY888e"
+            ],
+            "children": [
+                "9TqXzA"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ZYdREZ",
+                "QNPGzv"
+            ],
+            "children": [],
+            "branch": {
+                "left": [
+                    "through",
+                    "ZYdREZ"
+                ],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "t40i40": {
+            "name": [
+                "卡利多尼安路",
+                "Caledonian Road"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "RWDbkX"
+            ],
+            "children": [
+                "GRePRY"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "RWDbkX": {
+            "name": [
+                "霍洛威路",
+                "Holloway Road"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "PcuKjv"
+            ],
+            "children": [
+                "t40i40"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "PcuKjv": {
+            "name": [
+                "阿森纳",
+                "Arsenal"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "-c9T2D"
+            ],
+            "children": [
+                "RWDbkX"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "-c9T2D": {
+            "name": [
+                "芬斯伯里公园",
+                "Finsbury Park"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "S5SLIl"
+            ],
+            "children": [
+                "PcuKjv"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "victoria",
+                                    "#0098D8",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "维多利亚线",
+                                    "Victoria Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#ffffff",
+                                    "#000"
+                                ],
+                                "name": [
+                                    "国家铁路",
+                                    "National Rail"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "railway",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "S5SLIl": {
+            "name": [
+                "曼诺楼",
+                "Manor House"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "m6ZJvI"
+            ],
+            "children": [
+                "-c9T2D"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "m6ZJvI": {
+            "name": [
+                "登碧巷",
+                "Turnpike Lane"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "jQs-ch"
+            ],
+            "children": [
+                "S5SLIl"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "jQs-ch": {
+            "name": [
+                "伍德格林",
+                "Wood Green"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "TacArv"
+            ],
+            "children": [
+                "m6ZJvI"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "TacArv": {
+            "name": [
+                "磅林",
+                "Bounds Green"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "JDq_Dd"
+            ],
+            "children": [
+                "jQs-ch"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "JDq_Dd": {
+            "name": [
+                "亚诺斯·格罗夫",
+                "Arnos Grove"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "9TqXzA"
+            ],
+            "children": [
+                "TacArv"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "9TqXzA": {
+            "name": [
+                "南门",
+                "Southgate"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "eRk1KM"
+            ],
+            "children": [
+                "JDq_Dd"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "4dNq_g": {
+            "name": [
+                "海德公园角",
+                "Hyde Park Corner"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "xl5Er4"
+            ],
+            "children": [
+                "oA3iA6"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "xl5Er4": {
+            "name": [
+                "格林公园",
+                "Green Park"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "248AlE"
+            ],
+            "children": [
+                "4dNq_g"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "jubilee",
+                                    "#A1A5A7",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "银禧线",
+                                    "Jubilee Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "london",
+                                    "victoria",
+                                    "#0098D8",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "维多利亚线",
+                                    "Victoria Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "248AlE": {
+            "name": [
+                "皮卡迪利圆环",
+                "Piccadilly Circus"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "56Njdv"
+            ],
+            "children": [
+                "xl5Er4"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "bakerloo",
+                                    "#B26300",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "贝克卢线",
+                                    "Bakerloo Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "56Njdv": {
+            "name": [
+                "莱斯特广场",
+                "Leicester Square"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "GhK1vh"
+            ],
+            "children": [
+                "248AlE"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "northern",
+                                    "#000000",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "北线",
+                                    "Northern Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "GhK1vh": {
+            "name": [
+                "科芬园",
+                "Covent Garden"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "S3k3ts"
+            ],
+            "children": [
+                "56Njdv"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "S3k3ts": {
+            "name": [
+                "霍本",
+                "Holborn"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "UZ5CXs"
+            ],
+            "children": [
+                "GhK1vh"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "central",
+                                    "#DC241F",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央线",
+                                    "Central Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "UZ5CXs": {
+            "name": [
+                "罗素广场",
+                "Russell Square"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "GRePRY"
+            ],
+            "children": [
+                "S3k3ts"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "GRePRY": {
+            "name": [
+                "国王十字·圣潘克拉斯",
+                "King's Cross St. Pancras"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "t40i40"
+            ],
+            "children": [
+                "UZ5CXs"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "circle",
+                                    "#FFD329",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "环线",
+                                    "Circle Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "london",
+                                    "northern",
+                                    "#000000",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "北线",
+                                    "Northern Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "london",
+                                    "hsmithcity",
+                                    "#F4A9BE",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "汉默史密斯及城市线",
+                                    "H'smith & City Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "london",
+                                    "metropolitan",
+                                    "#9B0058",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大都会线",
+                                    "Metropolitan Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#ffffff",
+                                    "#000"
+                                ],
+                                "name": [
+                                    "国家铁路",
+                                    "National Rail"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "railway",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 650
+        },
+        "lOsxR5": {
+            "name": [
+                "阿克顿镇",
+                "Acton Town"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "1fKlJe"
+            ],
+            "children": [
+                "NMpTLC",
+                "5yGJGT"
+            ],
+            "branch": {
+                "left": [],
+                "right": [
+                    "through",
+                    "NMpTLC"
+                ]
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "district",
+                                    "#007D32",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "区域线",
+                                    "District Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "1fKlJe": {
+            "name": [
+                "汉默史密斯",
+                "Hammersmith"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "-6eRzp"
+            ],
+            "children": [
+                "lOsxR5"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "district",
+                                    "#007D32",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "区域线",
+                                    "District Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "hsmithcity",
+                                    "#F4A9BE",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "汉默史密斯及城市线",
+                                    "H'smith & City Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "london",
+                                    "circle",
+                                    "#FFD329",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "环线",
+                                    "Circle Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 400
+        },
+        "-6eRzp": {
+            "name": [
+                "男爵宫",
+                "Barons Court"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "bcsgyb"
+            ],
+            "children": [
+                "1fKlJe"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "district",
+                                    "#007D32",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "区域线",
+                                    "District Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "bcsgyb": {
+            "name": [
+                "伯爵宫",
+                "Earl's Court"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "xmWBz7"
+            ],
+            "children": [
+                "-6eRzp"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "district",
+                                    "#007D32",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "区域线",
+                                    "District Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "xmWBz7": {
+            "name": [
+                "格罗斯特路",
+                "Gloucester Road"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "y-KAcx"
+            ],
+            "children": [
+                "bcsgyb"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "circle",
+                                    "#FFD329",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "环线",
+                                    "Circle Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "london",
+                                    "district",
+                                    "#007D32",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "区域线",
+                                    "District Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "y-KAcx": {
+            "name": [
+                "南肯辛顿",
+                "South Kensingyon"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "oA3iA6"
+            ],
+            "children": [
+                "xmWBz7"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "circle",
+                                    "#FFD329",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "环线",
+                                    "Circle Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "london",
+                                    "district",
+                                    "#007D32",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "区域线",
+                                    "District Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "oA3iA6": {
+            "name": [
+                "骑士桥",
+                "Knightsbridge"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "4dNq_g"
+            ],
+            "children": [
+                "y-KAcx"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "5yGJGT": {
+            "name": [
+                "伊灵公园",
+                "Ealing Common"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "lOsxR5"
+            ],
+            "children": [
+                "uEkmVg"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "district",
+                                    "#007D32",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "区域线",
+                                    "District Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 185
+        },
+        "RIX3pb": {
+            "name": [
+                "莱斯里普",
+                "Ruislip"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "FGCSqw"
+            ],
+            "children": [
+                "YAJf-s"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "metropolitan",
+                                    "#9B0058",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大都会线",
+                                    "Metropolitan Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 300
+        },
+        "FGCSqw": {
+            "name": [
+                "莱斯里普庄园",
+                "Ruislip Manor"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "_wRISj"
+            ],
+            "children": [
+                "RIX3pb"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "metropolitan",
+                                    "#9B0058",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大都会线",
+                                    "Metropolitan Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 300
+        },
+        "_wRISj": {
+            "name": [
+                "东科特",
+                "Eastcote"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "9y4Jf6"
+            ],
+            "children": [
+                "FGCSqw"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "metropolitan",
+                                    "#9B0058",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大都会线",
+                                    "Metropolitan Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 300
+        },
+        "9y4Jf6": {
+            "name": [
+                "雷纳斯巷",
+                "Rayners Lane"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "cwk14W"
+            ],
+            "children": [
+                "_wRISj"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "metropolitan",
+                                    "#9B0058",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大都会线",
+                                    "Metropolitan Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 300
+        },
+        "cwk14W": {
+            "name": [
+                "南哈罗",
+                "South Harrow"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "xKFJqW"
+            ],
+            "children": [
+                "9y4Jf6"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "xKFJqW": {
+            "name": [
+                "萨德伯里山",
+                "Sudbury Hill"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "WRRvHc"
+            ],
+            "children": [
+                "cwk14W"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "WRRvHc": {
+            "name": [
+                "萨德伯里顿",
+                "Sudbury Town"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "vgZXX0"
+            ],
+            "children": [
+                "xKFJqW"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "vgZXX0": {
+            "name": [
+                "阿尔伯顿",
+                "Alperton"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "TriO2A"
+            ],
+            "children": [
+                "WRRvHc"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "TriO2A": {
+            "name": [
+                "皇家公园",
+                "Park Royal"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "uEkmVg"
+            ],
+            "children": [
+                "vgZXX0"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "uEkmVg": {
+            "name": [
+                "北伊灵",
+                "North Ealing"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "5yGJGT"
+            ],
+            "children": [
+                "TriO2A"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "NMpTLC": {
+            "name": [
+                "南伊灵",
+                "South Ealing"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "lOsxR5"
+            ],
+            "children": [
+                "i8X9Ri"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "QNPGzv": {
+            "name": [
+                "阿克斯桥",
+                "Uxbridge"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "NTtVb1"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "metropolitan",
+                                    "#9B0058",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大都会线",
+                                    "Metropolitan Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 300
+        },
+        "NTtVb1": {
+            "name": [
+                "希灵登",
+                "Hillingdon"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "YAJf-s"
+            ],
+            "children": [
+                "QNPGzv"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "metropolitan",
+                                    "#9B0058",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大都会线",
+                                    "Metropolitan Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 300
+        },
+        "YAJf-s": {
+            "name": [
+                "伊肯纳姆",
+                "Ickenham"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "RIX3pb"
+            ],
+            "children": [
+                "NTtVb1"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "london",
+                                    "metropolitan",
+                                    "#9B0058",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大都会线",
+                                    "Metropolitan Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 300
+        },
+        "sMVIj9": {
+            "name": [
+                "豪恩斯洛西",
+                "Hounslow West"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "6kMXWX"
+            ],
+            "children": [
+                "d1M7_X"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "6kMXWX": {
+            "name": [
+                "豪恩斯洛中",
+                "Hounslow Central"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "_b57V5"
+            ],
+            "children": [
+                "sMVIj9"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "_b57V5": {
+            "name": [
+                "豪恩斯洛东",
+                "Hounslow East"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "_VPA2J"
+            ],
+            "children": [
+                "6kMXWX"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "_VPA2J": {
+            "name": [
+                "奥斯特利",
+                "Osterley"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "wm7XFT"
+            ],
+            "children": [
+                "_b57V5"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "wm7XFT": {
+            "name": [
+                "波士顿庄园",
+                "Boston Manor"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "i8X9Ri"
+            ],
+            "children": [
+                "_VPA2J"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "i8X9Ri": {
+            "name": [
+                "诺斯菲尔德",
+                "Northfields"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "NMpTLC"
+            ],
+            "children": [
+                "wm7XFT"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "ZYdREZ": {
+            "name": [
+                "希斯罗5号航站楼",
+                "Heathrow T5"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "baTPKr"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "baTPKr": {
+            "name": [
+                "希斯罗2号&3号航站楼",
+                "Heathrow T2&3"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "d1M7_X"
+            ],
+            "children": [
+                "ZYdREZ"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "d1M7_X": {
+            "name": [
+                "赫顿十字",
+                "Hatton Cross"
+            ],
+            "secondaryName": false,
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "sMVIj9"
+            ],
+            "children": [
+                "baTPKr"
+            ],
+            "branch": {
+                "left": [],
+                "right": []
+            },
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": []
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "facility": "",
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": true
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "1",
+    "psd_num": "1",
+    "info_panel_type": "sh2020",
+    "notesGZMTR": [],
+    "direction_gz_x": 40,
+    "direction_gz_y": 70,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 0,
+        "bottom_factor": 1
+    }
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of London Tube on behalf of UnnamedKiana.
This should fix #707

**Review links**
[londontransport/piccadilly.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F416bf824d42f0920c2bd11ff3c034519579d5b08%2Fpublic%2Fresources%2Ftemplates%2Flondontransport%2Fpiccadilly.json)