### PR TITLE
Resources: New templates of East Japan Railway

### DIFF
--- a/public/resources/templates/JREAST/JK.json
+++ b/public/resources/templates/JREAST/JK.json
@@ -15,7 +15,7 @@
     "theme": [
         "tokyo",
         "jk",
-        "#1DAED1",
+        "#00b2e6",
         "#fff"
     ],
     "line_name": [
@@ -29,7 +29,6 @@
                 "RIGHT END",
                 "RIGHT END"
             ],
-            "secondaryName": false,
             "num": 0,
             "services": [
                 "local"
@@ -38,20 +37,13 @@
             "children": [
                 "V8nrMr"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -61,7 +53,6 @@
                 "大船",
                 "Ōfuna"
             ],
-            "secondaryName": false,
             "num": "47",
             "services": [
                 "local"
@@ -72,10 +63,6 @@
             "children": [
                 "lineend"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -84,7 +71,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jt",
-                                    "#F0862B",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -108,7 +95,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jo",
-                                    "#1069B4",
+                                    "#007ac0",
                                     "#fff"
                                 ],
                                 "name": [
@@ -130,14 +117,11 @@
                             }
                         ]
                     },
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": false
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -147,7 +131,6 @@
                 "\t本郷台",
                 "Hongōdai"
             ],
-            "secondaryName": false,
             "num": "46",
             "services": [
                 "local"
@@ -158,20 +141,13 @@
             "children": [
                 "FYa84J"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -181,7 +157,6 @@
                 "LEFT END",
                 "LEFT END"
             ],
-            "secondaryName": false,
             "num": 0,
             "services": [
                 "local"
@@ -190,20 +165,13 @@
                 "FYa84J"
             ],
             "children": [],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -213,7 +181,6 @@
                 "根岸",
                 "Negishi"
             ],
-            "secondaryName": false,
             "num": "41",
             "services": [
                 "local"
@@ -224,20 +191,13 @@
             "children": [
                 "u1nJvB"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -247,7 +207,6 @@
                 "磯子",
                 "Isogo"
             ],
-            "secondaryName": false,
             "num": "42",
             "services": [
                 "local"
@@ -258,20 +217,13 @@
             "children": [
                 "1aFnPZ"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -281,7 +233,6 @@
                 "新杉田\t",
                 "Shin-Sugita"
             ],
-            "secondaryName": false,
             "num": "43",
             "services": [
                 "local"
@@ -292,20 +243,13 @@
             "children": [
                 "gQgZNr"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -315,7 +259,6 @@
                 "洋光台",
                 "Yōkōdai"
             ],
-            "secondaryName": false,
             "num": "44",
             "services": [
                 "local"
@@ -326,20 +269,13 @@
             "children": [
                 "cjyO_l"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -349,7 +285,6 @@
                 "港南台",
                 "Kōnandai\t"
             ],
-            "secondaryName": false,
             "num": "45",
             "services": [
                 "local"
@@ -360,20 +295,13 @@
             "children": [
                 "wVeDLg"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -383,7 +311,6 @@
                 "高輪ゲートウェイ",
                 "Takanawa Gateway"
             ],
-            "secondaryName": false,
             "num": "27",
             "services": [
                 "local"
@@ -394,10 +321,6 @@
             "children": [
                 "cqbVO1"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -406,8 +329,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -452,7 +375,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -462,7 +384,6 @@
                 "品川",
                 "Shinagawa"
             ],
-            "secondaryName": false,
             "num": "28",
             "services": [
                 "local"
@@ -473,10 +394,6 @@
             "children": [
                 "yD6PH3"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -485,8 +402,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線 ",
@@ -497,7 +414,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jo",
-                                    "#1069B4",
+                                    "#007ac0",
                                     "#fff"
                                 ],
                                 "name": [
@@ -509,7 +426,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jt",
-                                    "#F0862B",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -543,14 +460,11 @@
                             }
                         ]
                     },
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": false
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -560,7 +474,6 @@
                 "大井町",
                 "Ōimachi"
             ],
-            "secondaryName": false,
             "num": "29",
             "services": [
                 "local"
@@ -571,10 +484,6 @@
             "children": [
                 "3UAxeb"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -605,14 +514,11 @@
                             }
                         ]
                     },
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -622,7 +528,6 @@
                 "大森",
                 "Ōmori"
             ],
-            "secondaryName": false,
             "num": "30",
             "services": [
                 "local"
@@ -633,20 +538,13 @@
             "children": [
                 "XEBHmJ"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -656,7 +554,6 @@
                 "\t蒲田",
                 "Kamata"
             ],
-            "secondaryName": false,
             "num": "31",
             "services": [
                 "local"
@@ -667,10 +564,6 @@
             "children": [
                 "G40lL4"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -705,7 +598,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -715,7 +607,6 @@
                 "川崎",
                 "Kawasaki"
             ],
-            "secondaryName": false,
             "num": "32",
             "services": [
                 "local"
@@ -726,10 +617,6 @@
             "children": [
                 "GgNE8D"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -738,7 +625,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jt",
-                                    "#F0862B",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -776,7 +663,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -786,7 +672,6 @@
                 "鶴見",
                 "Tsurumi"
             ],
-            "secondaryName": false,
             "num": "33",
             "services": [
                 "local"
@@ -797,10 +682,6 @@
             "children": [
                 "Xnm421"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -823,7 +704,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -833,7 +713,6 @@
                 "新子安",
                 "Shin-Koyasu"
             ],
-            "secondaryName": false,
             "num": "34",
             "services": [
                 "local"
@@ -844,20 +723,13 @@
             "children": [
                 "jj37F2"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -867,7 +739,6 @@
                 "東神奈川",
                 "Higashi-Kanagawa"
             ],
-            "secondaryName": false,
             "num": "35",
             "services": [
                 "local"
@@ -878,10 +749,6 @@
             "children": [
                 "dm2B8G"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -904,7 +771,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -914,7 +780,6 @@
                 "横浜",
                 "Yokohama"
             ],
-            "secondaryName": false,
             "num": "36",
             "services": [
                 "local"
@@ -925,10 +790,6 @@
             "children": [
                 "n2MXj9"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -937,7 +798,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jt",
-                                    "#F0862B",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -961,7 +822,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jo",
-                                    "#1069B4",
+                                    "#007ac0",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1043,14 +904,11 @@
                             }
                         ]
                     },
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -1060,7 +918,6 @@
                 "桜木町",
                 "Sakuragichō"
             ],
-            "secondaryName": false,
             "num": "37",
             "services": [
                 "local"
@@ -1071,10 +928,6 @@
             "children": [
                 "51idIp"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -1097,7 +950,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -1107,7 +959,6 @@
                 "関内",
                 "Kannai"
             ],
-            "secondaryName": false,
             "num": "38",
             "services": [
                 "local"
@@ -1118,10 +969,6 @@
             "children": [
                 "NvM1F7"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -1144,7 +991,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -1154,7 +1000,6 @@
                 "石川町",
                 "Ishikawachō"
             ],
-            "secondaryName": false,
             "num": "39",
             "services": [
                 "local"
@@ -1165,20 +1010,13 @@
             "children": [
                 "-_kvCF"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -1188,7 +1026,6 @@
                 "北浦和",
                 "Kita-Urawa"
             ],
-            "secondaryName": false,
             "num": "04",
             "services": [
                 "local"
@@ -1199,20 +1036,13 @@
             "children": [
                 "JWFhrH"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -1222,7 +1052,6 @@
                 "日暮里",
                 "Nippori"
             ],
-            "secondaryName": false,
             "num": "16",
             "services": [
                 "local"
@@ -1233,10 +1062,6 @@
             "children": [
                 "SnREPU"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -1245,8 +1070,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -1307,7 +1132,6 @@
                 "tick_direc": "l",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -1317,7 +1141,6 @@
                 "\t鶯谷",
                 "Uguisudani"
             ],
-            "secondaryName": false,
             "num": "17",
             "services": [
                 "local"
@@ -1328,10 +1151,6 @@
             "children": [
                 "eex0RF"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -1340,8 +1159,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -1354,7 +1173,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -1364,7 +1182,6 @@
                 "上野",
                 "Ueno"
             ],
-            "secondaryName": false,
             "num": "18",
             "services": [
                 "local"
@@ -1375,10 +1192,6 @@
             "children": [
                 "mWDIow"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -1387,8 +1200,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -1399,7 +1212,7 @@
                                 "theme": [
                                     "tokyo",
                                     "ju",
-                                    "#F18E41",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1423,7 +1236,7 @@
                                 "theme": [
                                     "tokyo",
                                     "ju",
-                                    "#F18E41",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1435,7 +1248,7 @@
                                 "theme": [
                                     "tokyo",
                                     "g",
-                                    "#ff9500",
+                                    "#f9a328",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1447,7 +1260,7 @@
                                 "theme": [
                                     "tokyo",
                                     "h",
-                                    "#b5b5ac",
+                                    "#c7beb3",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1477,14 +1290,11 @@
                             "Keisei-Ueno"
                         ]
                     },
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "l",
                 "paid_area": false
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -1494,7 +1304,6 @@
                 "御徒町",
                 "Okachimachi"
             ],
-            "secondaryName": false,
             "num": "19",
             "services": [
                 "local"
@@ -1505,10 +1314,6 @@
             "children": [
                 "nuPIYP"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -1517,8 +1322,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -1533,7 +1338,7 @@
                                 "theme": [
                                     "tokyo",
                                     "o",
-                                    "#ce045b",
+                                    "#ce1c64",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1545,7 +1350,7 @@
                                 "theme": [
                                     "tokyo",
                                     "g",
-                                    "#ff9500",
+                                    "#f9a328",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1557,7 +1362,7 @@
                                 "theme": [
                                     "tokyo",
                                     "h",
-                                    "#b5b5ac",
+                                    "#c7beb3",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1572,7 +1377,6 @@
                         ]
                     },
                     {
-                        "lines": [],
                         "name": [
                             "",
                             ""
@@ -1582,7 +1386,6 @@
                 "tick_direc": "l",
                 "paid_area": false
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -1592,7 +1395,6 @@
                 "\t秋葉原",
                 "Akihabara"
             ],
-            "secondaryName": false,
             "num": "20",
             "services": [
                 "local"
@@ -1603,10 +1405,6 @@
             "children": [
                 "Rf8ur9"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -1615,8 +1413,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -1627,8 +1425,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jb",
-                                    "#F2D01F",
-                                    "#fff"
+                                    "#fed304",
+                                    "#000"
                                 ],
                                 "name": [
                                     "総武線（各駅停車）",
@@ -1639,7 +1437,7 @@
                                 "theme": [
                                     "tokyo",
                                     "h",
-                                    "#b5b5ac",
+                                    "#c7beb3",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1651,7 +1449,7 @@
                                 "theme": [
                                     "tokyo",
                                     "s",
-                                    "#b0bf1e",
+                                    "#abba41",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1677,7 +1475,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -1687,7 +1484,6 @@
                 "神田",
                 "Kanda"
             ],
-            "secondaryName": false,
             "num": "21",
             "services": [
                 "local"
@@ -1698,10 +1494,6 @@
             "children": [
                 "5cYW6h"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -1710,7 +1502,7 @@
                                 "theme": [
                                     "tokyo",
                                     "g",
-                                    "#ff9500",
+                                    "#f9a328",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1722,7 +1514,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jc",
-                                    "#DD6935",
+                                    "#f15921",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1734,8 +1526,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -1748,7 +1540,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -1758,7 +1549,6 @@
                 "東京",
                 "Tōkyō"
             ],
-            "secondaryName": false,
             "num": "22",
             "services": [
                 "local"
@@ -1769,10 +1559,6 @@
             "children": [
                 "lOE1xx"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -1781,8 +1567,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -1793,7 +1579,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jt",
-                                    "#F0862B",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1805,7 +1591,7 @@
                                 "theme": [
                                     "tokyo",
                                     "ju",
-                                    "#F18E41",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1817,7 +1603,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jc",
-                                    "#DD6935",
+                                    "#f15921",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1829,7 +1615,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jo",
-                                    "#1069B4",
+                                    "#007ac0",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1857,7 +1643,7 @@
                                 "theme": [
                                     "tokyo",
                                     "m",
-                                    "#f62e36",
+                                    "#d92c2f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1869,7 +1655,7 @@
                                 "theme": [
                                     "tokyo",
                                     "t",
-                                    "#009bbf",
+                                    "#00a4db",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1881,7 +1667,7 @@
                                 "theme": [
                                     "tokyo",
                                     "c",
-                                    "#00bb85",
+                                    "#1bb267",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1893,7 +1679,7 @@
                                 "theme": [
                                     "tokyo",
                                     "z",
-                                    "#8f76d6",
+                                    "#8c7dba",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1905,7 +1691,7 @@
                                 "theme": [
                                     "tokyo",
                                     "i",
-                                    "#006ab8",
+                                    "#0068a5",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1923,7 +1709,6 @@
                 "tick_direc": "r",
                 "paid_area": false
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -1933,7 +1718,6 @@
                 "有楽町",
                 "Yūrakuchō"
             ],
-            "secondaryName": false,
             "num": "23",
             "services": [
                 "local"
@@ -1944,10 +1728,6 @@
             "children": [
                 "XWaY5P"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -1956,8 +1736,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -1968,7 +1748,7 @@
                                 "theme": [
                                     "tokyo",
                                     "y",
-                                    "#c1a470",
+                                    "#d1a662",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1984,7 +1764,7 @@
                                 "theme": [
                                     "tokyo",
                                     "c",
-                                    "#00bb85",
+                                    "#1bb267",
                                     "#fff"
                                 ],
                                 "name": [
@@ -1996,7 +1776,7 @@
                                 "theme": [
                                     "tokyo",
                                     "h",
-                                    "#b5b5ac",
+                                    "#c7beb3",
                                     "#fff"
                                 ],
                                 "name": [
@@ -2008,7 +1788,7 @@
                                 "theme": [
                                     "tokyo",
                                     "i",
-                                    "#006ab8",
+                                    "#0068a5",
                                     "#fff"
                                 ],
                                 "name": [
@@ -2046,14 +1826,11 @@
                             "Hibiya/Ginza"
                         ]
                     },
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "l",
                 "paid_area": false
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2063,7 +1840,6 @@
                 "新橋",
                 "Shimbashi"
             ],
-            "secondaryName": false,
             "num": "24",
             "services": [
                 "local"
@@ -2074,10 +1850,6 @@
             "children": [
                 "exuKD-"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -2086,7 +1858,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jt",
-                                    "#F0862B",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -2098,8 +1870,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -2110,7 +1882,7 @@
                                 "theme": [
                                     "tokyo",
                                     "jo",
-                                    "#1069B4",
+                                    "#007ac0",
                                     "#fff"
                                 ],
                                 "name": [
@@ -2122,7 +1894,7 @@
                                 "theme": [
                                     "tokyo",
                                     "g",
-                                    "#ff9500",
+                                    "#f9a328",
                                     "#fff"
                                 ],
                                 "name": [
@@ -2134,7 +1906,7 @@
                                 "theme": [
                                     "tokyo",
                                     "a",
-                                    "#ec6e65",
+                                    "#dd4231",
                                     "#fff"
                                 ],
                                 "name": [
@@ -2172,7 +1944,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2182,7 +1953,6 @@
                 "浜松町",
                 "Hamamatsuchō"
             ],
-            "secondaryName": false,
             "num": "25",
             "services": [
                 "local"
@@ -2193,10 +1963,6 @@
             "children": [
                 "Vjcwaz"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -2205,8 +1971,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -2263,7 +2029,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2273,7 +2038,6 @@
                 "田町",
                 "Tamachi"
             ],
-            "secondaryName": false,
             "num": "26",
             "services": [
                 "local"
@@ -2284,10 +2048,6 @@
             "children": [
                 "ZLDFmm"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -2296,8 +2056,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -2342,7 +2102,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2352,7 +2111,6 @@
                 "\t浦和",
                 "Urawa"
             ],
-            "secondaryName": false,
             "num": "05",
             "services": [
                 "local"
@@ -2363,10 +2121,6 @@
             "children": [
                 "z-8L8W"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -2413,7 +2167,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2423,7 +2176,6 @@
                 "南浦和",
                 "Minami-Urawa"
             ],
-            "secondaryName": false,
             "num": "06",
             "services": [
                 "local"
@@ -2434,10 +2186,6 @@
             "children": [
                 "ZJ2DcG"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -2460,7 +2208,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2470,7 +2217,6 @@
                 "蕨",
                 "Warabi"
             ],
-            "secondaryName": false,
             "num": "07",
             "services": [
                 "local"
@@ -2481,20 +2227,13 @@
             "children": [
                 "zohOfN"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2504,7 +2243,6 @@
                 "西川口",
                 "Nishi-Kawaguchi"
             ],
-            "secondaryName": false,
             "num": "08",
             "services": [
                 "local"
@@ -2515,20 +2253,13 @@
             "children": [
                 "7kovNF"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2538,7 +2269,6 @@
                 "川口",
                 "Kawaguchi"
             ],
-            "secondaryName": false,
             "num": "09",
             "services": [
                 "local"
@@ -2549,20 +2279,13 @@
             "children": [
                 "P-Ty2i"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2572,7 +2295,6 @@
                 "赤羽",
                 "Akabane"
             ],
-            "secondaryName": false,
             "num": "10",
             "services": [
                 "local"
@@ -2583,10 +2305,6 @@
             "children": [
                 "cj6Jl1"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -2595,7 +2313,7 @@
                                 "theme": [
                                     "tokyo",
                                     "ju",
-                                    "#F18E41",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -2619,7 +2337,7 @@
                                 "theme": [
                                     "tokyo",
                                     "ja",
-                                    "#14A676",
+                                    "#0ab38d",
                                     "#fff"
                                 ],
                                 "name": [
@@ -2645,7 +2363,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2655,7 +2372,6 @@
                 "東十条",
                 "Higashi-Jūjō"
             ],
-            "secondaryName": false,
             "num": "11",
             "services": [
                 "local"
@@ -2666,20 +2382,13 @@
             "children": [
                 "nug0uR"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2689,7 +2398,6 @@
                 "王子",
                 "Ōji"
             ],
-            "secondaryName": false,
             "num": "12",
             "services": [
                 "local"
@@ -2700,10 +2408,6 @@
             "children": [
                 "-b-IT0"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -2726,7 +2430,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2736,7 +2439,6 @@
                 "上中里",
                 "Kami-Nakazato"
             ],
-            "secondaryName": false,
             "num": "13",
             "services": [
                 "local"
@@ -2747,20 +2449,13 @@
             "children": [
                 "gROTTD"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2770,7 +2465,6 @@
                 "\t田端",
                 "Tabata"
             ],
-            "secondaryName": false,
             "num": "14",
             "services": [
                 "local"
@@ -2781,10 +2475,6 @@
             "children": [
                 "2krWzG"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -2793,8 +2483,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -2807,7 +2497,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2817,7 +2506,6 @@
                 "西日暮里\t",
                 "Nishi-Nippori"
             ],
-            "secondaryName": false,
             "num": "15",
             "services": [
                 "local"
@@ -2828,10 +2516,6 @@
             "children": [
                 "-b2g5B"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -2840,8 +2524,8 @@
                                 "theme": [
                                     "tokyo",
                                     "jy",
-                                    "#B1CB39",
-                                    "#fff"
+                                    "#7bab4f",
+                                    "#000"
                                 ],
                                 "name": [
                                     "山手線",
@@ -2866,7 +2550,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2876,7 +2559,6 @@
                 "大宮",
                 "Ōmiya"
             ],
-            "secondaryName": false,
             "num": "01",
             "services": [
                 "local"
@@ -2887,10 +2569,6 @@
             "children": [
                 "NPIcPP"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -2899,7 +2577,7 @@
                                 "theme": [
                                     "tokyo",
                                     "ju",
-                                    "#F18E41",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -2923,7 +2601,7 @@
                                 "theme": [
                                     "tokyo",
                                     "ja",
-                                    "#14A676",
+                                    "#0ab38d",
                                     "#fff"
                                 ],
                                 "name": [
@@ -2939,8 +2617,8 @@
                                     "#fff"
                                 ],
                                 "name": [
-                                    "東武アーバンパークライン",
-                                    "Tobu Urban Park Line Ina Line (New Shuttle)"
+                                    "東武アーバンパークライン（野田線h",
+                                    "Tobu Urban Park Line (Noda Line)"
                                 ]
                             },
                             {
@@ -2966,6 +2644,18 @@
                                     "上野東京線",
                                     "Ueno-Tokyo Line"
                                 ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ns",
+                                    "#18A698",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "伊奈線",
+                                    "Ina Line"
+                                ]
                             }
                         ]
                     }
@@ -2973,7 +2663,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -2983,7 +2672,6 @@
                 "埼玉新都心",
                 "Saitama-Shintoshin"
             ],
-            "secondaryName": false,
             "num": "02",
             "services": [
                 "local"
@@ -2994,10 +2682,6 @@
             "children": [
                 "HvjkB1"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
                     {
@@ -3006,7 +2690,7 @@
                                 "theme": [
                                     "tokyo",
                                     "ju",
-                                    "#F18E41",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -3018,7 +2702,7 @@
                                 "theme": [
                                     "tokyo",
                                     "ju",
-                                    "#F18E41",
+                                    "#f68b1f",
                                     "#fff"
                                 ],
                                 "name": [
@@ -3032,7 +2716,6 @@
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -3042,7 +2725,6 @@
                 "与野",
                 "Yono"
             ],
-            "secondaryName": false,
             "num": "03",
             "services": [
                 "local"
@@ -3053,20 +2735,13 @@
             "children": [
                 "B6hM5g"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -3076,7 +2751,6 @@
                 "山手",
                 "Yamate"
             ],
-            "secondaryName": false,
             "num": "40",
             "services": [
                 "local"
@@ -3087,20 +2761,13 @@
             "children": [
                 "Z_y9Kw"
             ],
-            "branch": {
-                "left": [],
-                "right": []
-            },
             "transfer": {
                 "groups": [
-                    {
-                        "lines": []
-                    }
+                    {}
                 ],
                 "tick_direc": "r",
                 "paid_area": true
             },
-            "facility": "",
             "loop_pivot": false,
             "one_line": true,
             "int_padding": 355
@@ -3117,7 +2784,6 @@
     "line_num": "JK",
     "psd_num": "1",
     "info_panel_type": "gz1",
-    "notesGZMTR": [],
     "direction_gz_x": 39,
     "direction_gz_y": 83,
     "coline": {},
@@ -3126,5 +2792,6 @@
         "bank": true,
         "left_and_right_factor": 1,
         "bottom_factor": 1
-    }
+    },
+    "version": "5.14.11"
 }


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of East Japan Railway on behalf of Charlis-Wong.
This should fix #731

**Review links**
[JREAST/JK.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fbe069fdeaaf905e5d9b7c277073b55eaf2553434%2Fpublic%2Fresources%2Ftemplates%2FJREAST%2FJK.json)