### PR TITLE
Resources: New templates of East Japan Railway

### DIFF
--- a/public/resources/templates/JREAST/--.json
+++ b/public/resources/templates/JREAST/--.json
@@ -1,0 +1,523 @@
+{
+    "svgWidth": {
+        "destination": 2000,
+        "runin": 1200,
+        "railmap": 5000,
+        "indoor": 5000
+    },
+    "svg_height": 500,
+    "style": "mtr",
+    "y_pc": 30,
+    "padding": 12,
+    "branchSpacingPct": 33,
+    "direction": "r",
+    "platform_num": 1,
+    "theme": [
+        "tokyo",
+        "na",
+        "#a6a9ab",
+        "#fff"
+    ],
+    "line_name": [
+        "川越線",
+        "Kawagoe Line"
+    ],
+    "current_stn_idx": "V8nrMr",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "num": 0,
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "V8nrMr"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "num": 0,
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "-_kvCF"
+            ],
+            "children": [],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "3UAxeb": {
+            "name": [
+                "的場",
+                "Matoba"
+            ],
+            "num": "30",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "-b-IT0"
+            ],
+            "children": [
+                "Xnm421"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Xnm421": {
+            "name": [
+                "笠幡",
+                "Kasahata"
+            ],
+            "num": "34",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "3UAxeb"
+            ],
+            "children": [
+                "NvM1F7"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "NvM1F7": {
+            "name": [
+                "武蔵高萩",
+                "Musashi-Takahagi"
+            ],
+            "num": "39",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Xnm421"
+            ],
+            "children": [
+                "-_kvCF"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "ZJ2DcG": {
+            "name": [
+                "西大宮",
+                "Nishi-Omiya"
+            ],
+            "num": "07",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "HvjkB1"
+            ],
+            "children": [
+                "zohOfN"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "zohOfN": {
+            "name": [
+                "指扇",
+                "Sashiogi"
+            ],
+            "num": "08",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ZJ2DcG"
+            ],
+            "children": [
+                "7kovNF"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "7kovNF": {
+            "name": [
+                "南古谷",
+                "Minami-Furuya"
+            ],
+            "num": "09",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "zohOfN"
+            ],
+            "children": [
+                "cj6Jl1"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "cj6Jl1": {
+            "name": [
+                "川越",
+                "Kawagoe"
+            ],
+            "num": "11",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "7kovNF"
+            ],
+            "children": [
+                "-b-IT0"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "tj",
+                                    "#00428E",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東武東上線",
+                                    "Tobu Tojo Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "name": [
+                            "本川越",
+                            "Hongawagoe"
+                        ]
+                    },
+                    {
+                        "name": [
+                            "本川越",
+                            "Hongawagoe"
+                        ],
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ss",
+                                    "#00A6BF",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "西武新宿線",
+                                    "Seibu Shinjuku Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "-b-IT0": {
+            "name": [
+                "西川越",
+                "Nishi-Kawagoe"
+            ],
+            "num": "13",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "cj6Jl1"
+            ],
+            "children": [
+                "3UAxeb"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "V8nrMr": {
+            "name": [
+                "大宮",
+                "Ōmiya"
+            ],
+            "num": "01",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "HvjkB1"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#f68b1f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "宇都宮線 · 高崎線",
+                                    "Utsunomiya Line·Takasaki Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "js",
+                                    "#DB2027",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "湘南新宿線",
+                                    "Shōnan-Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ja",
+                                    "#0ab38d",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "埼京線",
+                                    "Saikyō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "td",
+                                    "#40B4E5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東武アーバンパークライン（野田線）",
+                                    "Tobu Urban Park Line (Noda Line)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jm",
+                                    "#EB5A28",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "武藏野線",
+                                    "Musashino Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ju",
+                                    "#f68b1f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "上野東京線",
+                                    "Ueno-Tokyo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ns",
+                                    "#18A698",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "伊奈線",
+                                    "Ina Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京濱東北線",
+                                    "Keihin-Tohoku Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "HvjkB1": {
+            "name": [
+                "日進",
+                "Nisshin"
+            ],
+            "num": "03",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "V8nrMr"
+            ],
+            "children": [
+                "ZJ2DcG"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "-_kvCF": {
+            "name": [
+                "高麗川",
+                "Komagawa"
+            ],
+            "num": "40",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "NvM1F7"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": false,
+        "isFlip": false
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "-",
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "direction_gz_x": 39,
+    "direction_gz_y": 83,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    },
+    "version": "5.14.11"
+}

--- a/public/resources/templates/JREAST/00config.json
+++ b/public/resources/templates/JREAST/00config.json
@@ -18,5 +18,15 @@
             "ja": "山手線"
         },
         "uploadBy": "Takagi-Misae"
+    },
+    {
+        "filename": "--",
+        "name": {
+            "en": "Kawagoe Line",
+            "zh-Hans": "川越线",
+            "zh-Hant": "川越線",
+            "ja": "川越線"
+        },
+        "uploadBy": "Charlis-Wong"
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of East Japan Railway on behalf of Charlis-Wong.
This should fix #739

**Review links**
[JREAST/--.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fb338086e82735089d0c8a940c80b1d8c5844cff0%2Fpublic%2Fresources%2Ftemplates%2FJREAST%2F--.json)