### PR TITLE
Resources: New templates of Zhengzhou Metro

### DIFF
--- a/public/resources/templates/zzmetro/00config.json
+++ b/public/resources/templates/zzmetro/00config.json
@@ -70,5 +70,14 @@
             "zh-Hant": "14號線"
         },
         "uploadBy": "C1P918R"
+    },
+    {
+        "filename": "zz10",
+        "name": {
+            "en": "Line 10",
+            "zh-Hans": "10号线一期",
+            "zh-Hant": "10号线一期"
+        },
+        "uploadBy": "RapidHTTP"
     }
 ]

--- a/public/resources/templates/zzmetro/zz10.json
+++ b/public/resources/templates/zzmetro/zz10.json
@@ -1,0 +1,566 @@
+{
+    "svgViewBoxZoom": 90,
+    "svgViewBoxMin": {
+        "x": 344.50821533203134,
+        "y": -11.850354003906144
+    },
+    "graph": {
+        "options": {
+            "type": "directed",
+            "multi": true,
+            "allowSelfLoops": true
+        },
+        "attributes": {},
+        "nodes": [
+            {
+                "key": "stn_dRhLjOaGVV",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 575,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "郑州西站",
+                            "Zhengzhou Xizhan"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            },
+            {
+                "key": "stn_r6jISsjiBN",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 635,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "李商隐公园",
+                            "Lishangyingongyuan"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            },
+            {
+                "key": "stn_pgJEVnEE48",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 705,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "庙王",
+                            "Miaowang"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            },
+            {
+                "key": "stn_isxHaIRM7E",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 755,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "柳湖",
+                            "Liuhu"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            },
+            {
+                "key": "stn_lkopgp_aSI",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 800,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "市委党校",
+                            "Shiweidangxiao"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            },
+            {
+                "key": "stn_9jGlVpW6Lz",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 865,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "郑州一中",
+                            "Zhengzhouyizhong"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            },
+            {
+                "key": "stn_UAgiRUy0n3",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 930,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "西流湖",
+                            "Xiliuhu"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            },
+            {
+                "key": "stn_29JzriM5EX",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 980,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "秦岭路",
+                            "Qinlinglu"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            },
+            {
+                "key": "stn_BVUIG5QuTs",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 1030,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "二砂",
+                            "Ersha"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            },
+            {
+                "key": "stn_Gh9SETYkDu",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 1070,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "市中心医院",
+                            "Shizhongxinyiyuan"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            },
+            {
+                "key": "stn_pw1gMBySJI",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 1145,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "绿城广场",
+                            "Lvchengguangchang"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            },
+            {
+                "key": "stn_6dOy0kuLM2",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 1220,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "医学院",
+                            "Yixueyuan"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            },
+            {
+                "key": "stn_mJKDf4sJaq",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "x": 1280,
+                    "y": 305,
+                    "type": "shmetro-basic",
+                    "shmetro-basic": {
+                        "names": [
+                            "郑州火车站",
+                            "Zhengzhouhuachezhan"
+                        ],
+                        "nameOffsetX": "right",
+                        "nameOffsetY": "top"
+                    }
+                }
+            }
+        ],
+        "edges": [
+            {
+                "key": "line_E0kIxN7ksL",
+                "source": "stn_dRhLjOaGVV",
+                "target": "stn_r6jISsjiBN",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "type": "perpendicular",
+                    "perpendicular": {
+                        "startFrom": "from",
+                        "offsetFrom": 0,
+                        "offsetTo": 0,
+                        "roundCornerFactor": 18.33
+                    },
+                    "style": "single-color",
+                    "single-color": {
+                        "color": [
+                            "zhengzhou",
+                            "zz10",
+                            "#B15F56",
+                            "#fff"
+                        ]
+                    },
+                    "reconcileId": ""
+                }
+            },
+            {
+                "key": "line_2DJPr4iAbM",
+                "source": "stn_r6jISsjiBN",
+                "target": "stn_pgJEVnEE48",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "type": "perpendicular",
+                    "perpendicular": {
+                        "startFrom": "from",
+                        "offsetFrom": 0,
+                        "offsetTo": 0,
+                        "roundCornerFactor": 18.33
+                    },
+                    "style": "single-color",
+                    "single-color": {
+                        "color": [
+                            "zhengzhou",
+                            "zz10",
+                            "#B15F56",
+                            "#fff"
+                        ]
+                    },
+                    "reconcileId": ""
+                }
+            },
+            {
+                "key": "line_KP3LUp_32o",
+                "source": "stn_pgJEVnEE48",
+                "target": "stn_isxHaIRM7E",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "type": "perpendicular",
+                    "perpendicular": {
+                        "startFrom": "from",
+                        "offsetFrom": 0,
+                        "offsetTo": 0,
+                        "roundCornerFactor": 18.33
+                    },
+                    "style": "single-color",
+                    "single-color": {
+                        "color": [
+                            "zhengzhou",
+                            "zz10",
+                            "#B15F56",
+                            "#fff"
+                        ]
+                    },
+                    "reconcileId": ""
+                }
+            },
+            {
+                "key": "line_yP6NmeQ-dR",
+                "source": "stn_isxHaIRM7E",
+                "target": "stn_lkopgp_aSI",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "type": "perpendicular",
+                    "perpendicular": {
+                        "startFrom": "from",
+                        "offsetFrom": 0,
+                        "offsetTo": 0,
+                        "roundCornerFactor": 18.33
+                    },
+                    "style": "single-color",
+                    "single-color": {
+                        "color": [
+                            "zhengzhou",
+                            "zz10",
+                            "#B15F56",
+                            "#fff"
+                        ]
+                    },
+                    "reconcileId": ""
+                }
+            },
+            {
+                "key": "line_9XM7oSuux9",
+                "source": "stn_lkopgp_aSI",
+                "target": "stn_9jGlVpW6Lz",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "type": "perpendicular",
+                    "perpendicular": {
+                        "startFrom": "from",
+                        "offsetFrom": 0,
+                        "offsetTo": 0,
+                        "roundCornerFactor": 18.33
+                    },
+                    "style": "single-color",
+                    "single-color": {
+                        "color": [
+                            "zhengzhou",
+                            "zz10",
+                            "#B15F56",
+                            "#fff"
+                        ]
+                    },
+                    "reconcileId": ""
+                }
+            },
+            {
+                "key": "line_BcU6J3I8hy",
+                "source": "stn_9jGlVpW6Lz",
+                "target": "stn_UAgiRUy0n3",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "type": "perpendicular",
+                    "perpendicular": {
+                        "startFrom": "from",
+                        "offsetFrom": 0,
+                        "offsetTo": 0,
+                        "roundCornerFactor": 18.33
+                    },
+                    "style": "single-color",
+                    "single-color": {
+                        "color": [
+                            "zhengzhou",
+                            "zz10",
+                            "#B15F56",
+                            "#fff"
+                        ]
+                    },
+                    "reconcileId": ""
+                }
+            },
+            {
+                "key": "line_jxW7d1EulQ",
+                "source": "stn_UAgiRUy0n3",
+                "target": "stn_29JzriM5EX",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "type": "perpendicular",
+                    "perpendicular": {
+                        "startFrom": "from",
+                        "offsetFrom": 0,
+                        "offsetTo": 0,
+                        "roundCornerFactor": 18.33
+                    },
+                    "style": "single-color",
+                    "single-color": {
+                        "color": [
+                            "zhengzhou",
+                            "zz10",
+                            "#B15F56",
+                            "#fff"
+                        ]
+                    },
+                    "reconcileId": ""
+                }
+            },
+            {
+                "key": "line_Tc-HPY0tAT",
+                "source": "stn_29JzriM5EX",
+                "target": "stn_BVUIG5QuTs",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "type": "perpendicular",
+                    "perpendicular": {
+                        "startFrom": "from",
+                        "offsetFrom": 0,
+                        "offsetTo": 0,
+                        "roundCornerFactor": 18.33
+                    },
+                    "style": "single-color",
+                    "single-color": {
+                        "color": [
+                            "zhengzhou",
+                            "zz10",
+                            "#B15F56",
+                            "#fff"
+                        ]
+                    },
+                    "reconcileId": ""
+                }
+            },
+            {
+                "key": "line_LA_uZQ54zc",
+                "source": "stn_BVUIG5QuTs",
+                "target": "stn_Gh9SETYkDu",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "type": "perpendicular",
+                    "perpendicular": {
+                        "startFrom": "from",
+                        "offsetFrom": 0,
+                        "offsetTo": 0,
+                        "roundCornerFactor": 18.33
+                    },
+                    "style": "single-color",
+                    "single-color": {
+                        "color": [
+                            "zhengzhou",
+                            "zz10",
+                            "#B15F56",
+                            "#fff"
+                        ]
+                    },
+                    "reconcileId": ""
+                }
+            },
+            {
+                "key": "line_PmkjsgteUt",
+                "source": "stn_Gh9SETYkDu",
+                "target": "stn_pw1gMBySJI",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "type": "perpendicular",
+                    "perpendicular": {
+                        "startFrom": "from",
+                        "offsetFrom": 0,
+                        "offsetTo": 0,
+                        "roundCornerFactor": 18.33
+                    },
+                    "style": "single-color",
+                    "single-color": {
+                        "color": [
+                            "zhengzhou",
+                            "zz10",
+                            "#B15F56",
+                            "#fff"
+                        ]
+                    },
+                    "reconcileId": ""
+                }
+            },
+            {
+                "key": "line_b5MVLPuT4B",
+                "source": "stn_pw1gMBySJI",
+                "target": "stn_6dOy0kuLM2",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "type": "perpendicular",
+                    "perpendicular": {
+                        "startFrom": "from",
+                        "offsetFrom": 0,
+                        "offsetTo": 0,
+                        "roundCornerFactor": 18.33
+                    },
+                    "style": "single-color",
+                    "single-color": {
+                        "color": [
+                            "zhengzhou",
+                            "zz10",
+                            "#B15F56",
+                            "#fff"
+                        ]
+                    },
+                    "reconcileId": ""
+                }
+            },
+            {
+                "key": "line_hxkt3-BW8F",
+                "source": "stn_6dOy0kuLM2",
+                "target": "stn_mJKDf4sJaq",
+                "attributes": {
+                    "visible": true,
+                    "zIndex": 0,
+                    "type": "perpendicular",
+                    "perpendicular": {
+                        "startFrom": "from",
+                        "offsetFrom": 0,
+                        "offsetTo": 0,
+                        "roundCornerFactor": 18.33
+                    },
+                    "style": "single-color",
+                    "single-color": {
+                        "color": [
+                            "zhengzhou",
+                            "zz10",
+                            "#B15F56",
+                            "#fff"
+                        ]
+                    },
+                    "reconcileId": ""
+                }
+            }
+        ]
+    },
+    "version": 19
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Zhengzhou Metro on behalf of RapidHTTP.
This should fix #747

**Review links**
[zzmetro/zz10.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fd2b79df0902c34767e71dc2223014222b44e2f67%2Fpublic%2Fresources%2Ftemplates%2Fzzmetro%2Fzz10.json)