### PR TITLE
Resources: New templates of Tokyo Metro

### DIFF
--- a/public/resources/templates/tyometro/00config.json
+++ b/public/resources/templates/tyometro/00config.json
@@ -18,5 +18,15 @@
             "ja": "有楽町線"
         },
         "uploadBy": "Charlis-Wong"
+    },
+    {
+        "filename": "C",
+        "name": {
+            "en": "Chiyoda Line",
+            "zh-Hans": "千代田线",
+            "zh-Hant": "千代田線",
+            "ja": "千代田線"
+        },
+        "uploadBy": "Charlis-Wong"
     }
 ]

--- a/public/resources/templates/tyometro/C.json
+++ b/public/resources/templates/tyometro/C.json
@@ -5,7 +5,7 @@
         "railmap": 10000,
         "indoor": 10000
     },
-    "svg_height": 450,
+    "svg_height": 600,
     "style": "shmetro",
     "y_pc": 36,
     "padding": 10,
@@ -202,7 +202,7 @@
             },
             "loop_pivot": false,
             "one_line": true,
-            "int_padding": 355
+            "int_padding": 500
         },
         "9hM_EB": {
             "name": [
@@ -329,7 +329,7 @@
             },
             "loop_pivot": false,
             "one_line": true,
-            "int_padding": 355
+            "int_padding": 400
         },
         "ivu4t7": {
             "name": [
@@ -516,7 +516,7 @@
             },
             "loop_pivot": false,
             "one_line": true,
-            "int_padding": 355
+            "int_padding": 650
         },
         "6FzOjv": {
             "name": [
@@ -802,7 +802,7 @@
             },
             "loop_pivot": false,
             "one_line": true,
-            "int_padding": 355
+            "int_padding": 450
         },
         "E7S5Fy": {
             "name": [
@@ -932,7 +932,7 @@
         },
         "Q_gf80": {
             "name": [
-                "赤坂",
+                "赤坂（TBS前）",
                 "Akasaka"
             ],
             "num": "06",

--- a/public/resources/templates/tyometro/C.json
+++ b/public/resources/templates/tyometro/C.json
@@ -1,0 +1,1229 @@
+{
+    "svgWidth": {
+        "destination": 2000,
+        "runin": 2500,
+        "railmap": 10000,
+        "indoor": 10000
+    },
+    "svg_height": 450,
+    "style": "shmetro",
+    "y_pc": 36,
+    "padding": 10,
+    "branchSpacingPct": 33,
+    "direction": "r",
+    "platform_num": "1",
+    "theme": [
+        "tokyo",
+        "c",
+        "#1bb267",
+        "#fff"
+    ],
+    "line_name": [
+        "千代田線",
+        "Chiyoda Line"
+    ],
+    "current_stn_idx": "KgVpo3",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "KgVpo3"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "1aaMf3": {
+            "name": [
+                "北綾瀬",
+                "Kita-Ayase"
+            ],
+            "num": "20",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "bbzyAf"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "bbzyAf": {
+            "name": [
+                "綾瀬",
+                "Ayase"
+            ],
+            "num": "19",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ZPQMw7"
+            ],
+            "children": [
+                "1aaMf3"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jl",
+                                    "#868587",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "常磐線（各駅停車）",
+                                    "Joban Line (Local)"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "1aaMf3"
+            ],
+            "children": [],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "ZPQMw7": {
+            "name": [
+                "北千住",
+                "Kita-Senju"
+            ],
+            "num": "18",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "9hM_EB"
+            ],
+            "children": [
+                "bbzyAf"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#c7beb3",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Hibiya Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jj",
+                                    "#1DAF7E",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "常磐線（快速）",
+                                    "Joban Line (Rapid)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ts",
+                                    "#006CBA",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東武晴空塔線（伊勢崎線）",
+                                    "Tobu Skytree Line (Isesaki Line)"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "9hM_EB": {
+            "name": [
+                "町屋",
+                "Machiya"
+            ],
+            "num": "17",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "5rpLUm"
+            ],
+            "children": [
+                "ZPQMw7"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "ks",
+                                    "#005AAA",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京成本線",
+                                    "Keisei Main Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {},
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "sa",
+                                    "#d75b80",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "荒川線",
+                                    "Arakawa Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "町屋站前",
+                            "Machiya-Ekimae"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "5rpLUm": {
+            "name": [
+                "西日暮里",
+                "Nishi-Nippori"
+            ],
+            "num": "16",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ivu4t7"
+            ],
+            "children": [
+                "9hM_EB"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#7bab4f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tohoku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "nt",
+                                    "#D53A77",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日暮里-舍人線",
+                                    "Nippori-Toneri Liner "
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "ivu4t7": {
+            "name": [
+                "千駄木",
+                "Sendagi"
+            ],
+            "num": "15",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "gXH7Tf"
+            ],
+            "children": [
+                "5rpLUm"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "gXH7Tf": {
+            "name": [
+                "根津",
+                "Nezu"
+            ],
+            "num": "14",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "o-p2Ip"
+            ],
+            "children": [
+                "ivu4t7"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "o-p2Ip": {
+            "name": [
+                "湯島",
+                "Yushima"
+            ],
+            "num": "13",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "-UTlSt"
+            ],
+            "children": [
+                "gXH7Tf"
+            ],
+            "transfer": {
+                "groups": [
+                    {},
+                    {},
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "o",
+                                    "#ce1c64",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大江戶線",
+                                    "Oedo Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "上野御徒町",
+                            "Ueno-Okachimachi"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "-UTlSt": {
+            "name": [
+                "新御茶ノ水",
+                "Shin-Ochanomico"
+            ],
+            "num": "12",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "6FzOjv"
+            ],
+            "children": [
+                "o-p2Ip"
+            ],
+            "transfer": {
+                "groups": [
+                    {},
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "s",
+                                    "#abba41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "新宿線",
+                                    "Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸之內線",
+                                    "Marunouchi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jc",
+                                    "#f15921",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央線（快速）",
+                                    "Chuo Line (Rapid)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#fed304",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央 · 總武線（各駅停車）",
+                                    "Chuo · Sobu Line (Local)"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "小川町/淡路町/御茶ノ水",
+                            "Ogawamachi Awajicho"
+                        ]
+                    },
+                    {
+                        "name": [
+                            "",
+                            ""
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "6FzOjv": {
+            "name": [
+                "大手町",
+                "Otemachi"
+            ],
+            "num": "11",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "d6KGkJ"
+            ],
+            "children": [
+                "-UTlSt"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#0068a5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "三田線",
+                                    "Mita Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "t",
+                                    "#00a4db",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東西線",
+                                    "Tōzai Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸之內線",
+                                    "Marunouchi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "z",
+                                    "#8c7dba",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "半藏門線",
+                                    "Hanzōmon Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "d6KGkJ": {
+            "name": [
+                "二重橋前〈丸の内〉",
+                "Nijubashimae (Marunouchi)"
+            ],
+            "num": "10",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "kw-1rh"
+            ],
+            "children": [
+                "6FzOjv"
+            ],
+            "transfer": {
+                "groups": [
+                    {},
+                    {
+                        "name": [
+                            "",
+                            ""
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#7bab4f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tohoku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jc",
+                                    "#f15921",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央線",
+                                    "Chuo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jt",
+                                    "#f68b1f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東海道線",
+                                    "Tokkaido Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jo",
+                                    "#007ac0",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "總武線(快速）· 橫須賀線",
+                                    "Sobu Line (Rapid) · Yokosuka Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "je",
+                                    "#D01827",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京葉線",
+                                    "Keiyo Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "東京",
+                            "Tokyo"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "kw-1rh": {
+            "name": [
+                "日比谷",
+                "Hibiya"
+            ],
+            "num": "09",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "E7S5Fy"
+            ],
+            "children": [
+                "d6KGkJ"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#0068a5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "三田線",
+                                    "Mita Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#c7beb3",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Hibiya Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yūrakuchō Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#7bab4f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京浜東北線",
+                                    "Keihin-Tohoku Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "有楽町",
+                            "Yurakocho"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "E7S5Fy": {
+            "name": [
+                "霞ケ関",
+                "Kusumigaseki"
+            ],
+            "num": "08",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "sT9jI1"
+            ],
+            "children": [
+                "kw-1rh"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#c7beb3",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Hibiya Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸之內線",
+                                    "Marunouchi Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "sT9jI1": {
+            "name": [
+                "国会議事堂前",
+                "Kokkai-Gijidomae"
+            ],
+            "num": "07",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Q_gf80"
+            ],
+            "children": [
+                "E7S5Fy"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸之內線",
+                                    "Marunouchi Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#f9a328",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "n",
+                                    "#02b69b",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "南北線",
+                                    "Namboku Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "溜池山王",
+                            "Tameike-Sanno"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Q_gf80": {
+            "name": [
+                "赤坂",
+                "Akasaka"
+            ],
+            "num": "06",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "vzyjcn"
+            ],
+            "children": [
+                "sT9jI1"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "vzyjcn": {
+            "name": [
+                "乃木坂",
+                "Nogizaka"
+            ],
+            "num": "05",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "OlPWQN"
+            ],
+            "children": [
+                "Q_gf80"
+            ],
+            "transfer": {
+                "groups": [
+                    {},
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "h",
+                                    "#c7beb3",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "日比谷線",
+                                    "Hibiya Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "六本木",
+                            "Roppongi"
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "o",
+                                    "#ce1c64",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大江戶線",
+                                    "Oedo Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "六本木",
+                            "Roppongi"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "OlPWQN": {
+            "name": [
+                "表参道",
+                "Omote-Sando"
+            ],
+            "num": "04",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "gq8Lgb"
+            ],
+            "children": [
+                "vzyjcn"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "z",
+                                    "#8c7dba",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "半藏門線",
+                                    "Hanzōmon Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#f9a328",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "gq8Lgb": {
+            "name": [
+                "明治神宮前〈原宿〉",
+                "Meiji-Jingumae 'Harajuku'"
+            ],
+            "num": "03",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "UW8MzO"
+            ],
+            "children": [
+                "OlPWQN"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "f",
+                                    "#9c5e31",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "副都心線",
+                                    "Fukutoshin Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {},
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#7bab4f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "原宿",
+                            "Harajuku"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "UW8MzO": {
+            "name": [
+                "代々木公園",
+                "Yoyogi-Koen"
+            ],
+            "num": "02",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "KgVpo3"
+            ],
+            "children": [
+                "gq8Lgb"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "KgVpo3": {
+            "name": [
+                "代々木上原",
+                "Yoyogi-Uehara"
+            ],
+            "num": "01",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "UW8MzO"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "oh",
+                                    "#0085CE",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "小田原線",
+                                    "Odawara Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": true
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "C",
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "direction_gz_x": 34,
+    "direction_gz_y": 76,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    },
+    "version": "5.14.12"
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Tokyo Metro on behalf of Charlis-Wong.
This should fix #759

**Review links**
[tyometro/C.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F59ad24627bb6ecfe85d3443e4afda3f8eb210a54%2Fpublic%2Fresources%2Ftemplates%2Ftyometro%2FC.json)