### PR TITLE
Resources: New templates of Osaka Metro

### DIFF
--- a/public/resources/other-company-config.json
+++ b/public/resources/other-company-config.json
@@ -294,6 +294,14 @@
         }
     },
     {
+        "id": "OMTR",
+        "name": {
+            "en": "Osaka Metro",
+            "zh-Hans": " 序言 线路列表 切换 线路列表 小节 运营线路 延伸线 新规划线路 车费 车辆 关联企业 注释 参考文献 外部链接 大阪市高速电气轨道",
+            "zh-Hant": "大阪市高速電氣軌道"
+        }
+    },
+    {
         "id": "qdmetro",
         "name": {
             "en": "Qingdao Metro",

--- a/public/resources/templates/OMTR/00config.json
+++ b/public/resources/templates/OMTR/00config.json
@@ -1,0 +1,12 @@
+[
+    {
+        "filename": "M",
+        "name": {
+            "en": "Midōsuji Line",
+            "zh-Hans": "御堂筋线",
+            "zh-Hant": "御堂筋線",
+            "ja": "御堂筋線"
+        },
+        "uploadBy": "TDX8112"
+    }
+]

--- a/public/resources/templates/OMTR/M.json
+++ b/public/resources/templates/OMTR/M.json
@@ -1,0 +1,744 @@
+{
+    "svgWidth": {
+        "destination": 1200,
+        "runin": 2000,
+        "railmap": 2000,
+        "indoor": 1200
+    },
+    "svg_height": 500,
+    "style": "gzmtr",
+    "y_pc": 44,
+    "padding": 6,
+    "branchSpacingPct": 38,
+    "direction": "r",
+    "platform_num": "1",
+    "theme": [
+        "hongkong",
+        "twl",
+        "#E2231A",
+        "#fff"
+    ],
+    "line_name": [
+        "御堂筋线",
+        "Midosuji Line"
+    ],
+    "current_stn_idx": "YO4Xzt",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "X1yK-i"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "X1yK-i": {
+            "name": [
+                "江阪",
+                "Esaka"
+            ],
+            "num": "11",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "ZNFNAX"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "ZNFNAX": {
+            "name": [
+                "东三国",
+                "Higashi-Mikuni"
+            ],
+            "num": "12",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "X1yK-i"
+            ],
+            "children": [
+                "5gJiGD"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "dZU0OW"
+            ],
+            "children": [],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "dZU0OW": {
+            "name": [
+                "中百舌鸟",
+                "Naka-Mozu"
+            ],
+            "num": "30",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Vc2Nuo"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Vc2Nuo": {
+            "name": [
+                "新金冈",
+                "Shin-Kanaoka"
+            ],
+            "num": "29",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "IElxuj"
+            ],
+            "children": [
+                "dZU0OW"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "IElxuj": {
+            "name": [
+                "北花田",
+                "Kita-Hanada"
+            ],
+            "num": "28",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "hEYYt9"
+            ],
+            "children": [
+                "Vc2Nuo"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "hEYYt9": {
+            "name": [
+                "我孙子",
+                "Abiko"
+            ],
+            "num": "27",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "mm6dz2"
+            ],
+            "children": [
+                "IElxuj"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "mm6dz2": {
+            "name": [
+                "长居",
+                "Nagai"
+            ],
+            "num": "26",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "qSNhGD"
+            ],
+            "children": [
+                "hEYYt9"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "qSNhGD": {
+            "name": [
+                "西田边",
+                "Nishi-Tanabe"
+            ],
+            "num": "25",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Z1L8Tu"
+            ],
+            "children": [
+                "mm6dz2"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Z1L8Tu": {
+            "name": [
+                "昭和町",
+                "Shōwachō"
+            ],
+            "num": "24",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "h7ZEE3"
+            ],
+            "children": [
+                "qSNhGD"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "h7ZEE3": {
+            "name": [
+                "天王寺",
+                "Tennōji"
+            ],
+            "num": "23",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "xW6mmT"
+            ],
+            "children": [
+                "Z1L8Tu"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#7D26CD",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "谷町线",
+                                    "Tanimachi Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "xW6mmT": {
+            "name": [
+                "动物园前",
+                "Dōbutsuen-mae"
+            ],
+            "num": "22",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "-U_4BR"
+            ],
+            "children": [
+                "h7ZEE3"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#8B4513",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "堺筋线",
+                                    "Sakaisuji Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "-U_4BR": {
+            "name": [
+                "大国町",
+                "Daikokuchō"
+            ],
+            "num": "21",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "YO4Xzt"
+            ],
+            "children": [
+                "xW6mmT"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#1874CD",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "四桥线",
+                                    "Yotsubashi Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "YO4Xzt": {
+            "name": [
+                "难波",
+                "Namba"
+            ],
+            "num": "20",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "kGPGvx"
+            ],
+            "children": [
+                "-U_4BR"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#1874CD",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "四桥线",
+                                    "Yotsubashi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#FF83FA",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "千日前线",
+                                    "Sennichimae Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "kGPGvx": {
+            "name": [
+                "心斋桥",
+                "Shinsaibashi"
+            ],
+            "num": "19",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "nT3wmT"
+            ],
+            "children": [
+                "YO4Xzt"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#9ACD32",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "长堀鹤见绿地线",
+                                    "Nagahori-Tsurumi-Ryokuchi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#1874CD",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "四桥线",
+                                    "Yotsubashi Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "nT3wmT": {
+            "name": [
+                "本町",
+                "Hommachi"
+            ],
+            "num": "18",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "PoqyTs"
+            ],
+            "children": [
+                "kGPGvx"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "PoqyTs": {
+            "name": [
+                "淀屋桥",
+                "Yodoyabashi"
+            ],
+            "num": "17",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "2Dvlrj"
+            ],
+            "children": [
+                "nT3wmT"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "2Dvlrj": {
+            "name": [
+                "梅田",
+                "Umeda"
+            ],
+            "num": "16",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "abmxC_"
+            ],
+            "children": [
+                "PoqyTs"
+            ],
+            "transfer": {
+                "groups": [
+                    {},
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#7D26CD",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "谷町线",
+                                    "Tanimachi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#1874CD",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "四桥线",
+                                    "Yotsubashi Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "abmxC_": {
+            "name": [
+                "中津",
+                "Nakatsu"
+            ],
+            "num": "15",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "IMgPAC"
+            ],
+            "children": [
+                "2Dvlrj"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "IMgPAC": {
+            "name": [
+                "西中岛南方",
+                "NishiNakajima-Minamigata"
+            ],
+            "num": "14",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "5gJiGD"
+            ],
+            "children": [
+                "abmxC_"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "5gJiGD": {
+            "name": [
+                "新大阪",
+                "Shin-Ōsaka"
+            ],
+            "num": "13",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ZNFNAX"
+            ],
+            "children": [
+                "IMgPAC"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": true
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "M",
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "direction_gz_x": 27,
+    "direction_gz_y": 74,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    },
+    "version": "5.14.12"
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Osaka Metro on behalf of TDX8112.
This should fix #795

**Review links**
[OMTR/M.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F2a7dce610f4ff1edff3cf681e286beefce980a2b%2Fpublic%2Fresources%2Ftemplates%2FOMTR%2FM.json)