### PR TITLE
Resources: New templates of Tokyo Metro

### DIFF
--- a/public/resources/templates/tyometro/00config.json
+++ b/public/resources/templates/tyometro/00config.json
@@ -38,5 +38,15 @@
             "ja": "千代田線"
         },
         "uploadBy": "Charlis-Wong"
+    },
+    {
+        "filename": "N",
+        "name": {
+            "en": "Namboku Line",
+            "zh-Hans": "南北线",
+            "zh-Hant": "南北線",
+            "ja": "南北線"
+        },
+        "uploadBy": "Charlis-Wong"
     }
 ]

--- a/public/resources/templates/tyometro/N.json
+++ b/public/resources/templates/tyometro/N.json
@@ -1,0 +1,949 @@
+{
+    "svgWidth": {
+        "destination": 1700,
+        "runin": 1200,
+        "railmap": 5000,
+        "indoor": 7000
+    },
+    "svg_height": 450,
+    "style": "shmetro",
+    "y_pc": 50,
+    "padding": 10,
+    "branchSpacingPct": 33,
+    "direction": "r",
+    "platform_num": "1",
+    "theme": [
+        "tokyo",
+        "n",
+        "#02b69b",
+        "#fff"
+    ],
+    "line_name": [
+        "南北線",
+        "Namboku Line"
+    ],
+    "current_stn_idx": "cKSESb",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "cKSESb"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "cKSESb": {
+            "name": [
+                "目黑",
+                "Meguro"
+            ],
+            "num": "01",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "vhobeJ"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "mg",
+                                    "#009CD3",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東急目黒線",
+                                    "Tokyu Meguro Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#0068a5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営三田線",
+                                    "Toei Mita Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#7bab4f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "vhobeJ": {
+            "name": [
+                "白金台",
+                "Shirokanedai"
+            ],
+            "num": "02",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "cKSESb"
+            ],
+            "children": [
+                "Wz1reC"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#0068a5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営三田線",
+                                    "Toei Mita Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "vRHUXa"
+            ],
+            "children": [],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Wz1reC": {
+            "name": [
+                "白金高輪",
+                "Shirokane-Takanawa"
+            ],
+            "num": "03",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "vhobeJ"
+            ],
+            "children": [
+                "ioWV88"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#0068a5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営三田線",
+                                    "Toei Mita Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "ioWV88": {
+            "name": [
+                "麻布十番",
+                "Azabu-Juban"
+            ],
+            "num": "04",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Wz1reC"
+            ],
+            "children": [
+                "k9cVOZ"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "o",
+                                    "#ce1c64",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営大江戶線",
+                                    "Toei Oedo Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "k9cVOZ": {
+            "name": [
+                "六本木一丁目",
+                "Roppongi-Itchome"
+            ],
+            "num": "05",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ioWV88"
+            ],
+            "children": [
+                "sGuSVh"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "sGuSVh": {
+            "name": [
+                "溜池山王",
+                "Tameike-Sanno"
+            ],
+            "num": "06",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "k9cVOZ"
+            ],
+            "children": [
+                "9ut_OH"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#f9a328",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸之內線",
+                                    "Marunouchi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "c",
+                                    "#1bb267",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "千代田線",
+                                    "Chiyoda Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "国会議事堂前",
+                            "Kokkai-Gijidōmae"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "9ut_OH": {
+            "name": [
+                "永田町",
+                "Nagatacho"
+            ],
+            "num": "07",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "sGuSVh"
+            ],
+            "children": [
+                "kzaR23"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "z",
+                                    "#8c7dba",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "半藏門線",
+                                    "Hanzomon Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yurakucho Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸之內線",
+                                    "Marunouchi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#f9a328",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "赤坂見附",
+                            "Akasaka-Mitsuke"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "kzaR23": {
+            "name": [
+                "四ツ谷",
+                "Yotsuya"
+            ],
+            "num": "08",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "9ut_OH"
+            ],
+            "children": [
+                "kw7hhr"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸之內線",
+                                    "Marunouchi Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jc",
+                                    "#f15921",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央線（快速）",
+                                    "Chuo Line (Rapid)"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#fed304",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央線（各駅停車）",
+                                    "Chuo Line (Local)"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "kw7hhr": {
+            "name": [
+                "市ケ谷",
+                "Ichigaya"
+            ],
+            "num": "09",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "kzaR23"
+            ],
+            "children": [
+                "tR9CVr"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yurakucho Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "s",
+                                    "#abba41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営新宿線",
+                                    "Toei Shinjuku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#fed304",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央線（各駅停車）",
+                                    "Chuo Line (Local)"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "tR9CVr": {
+            "name": [
+                "飯田橋",
+                "Iidabashi"
+            ],
+            "num": "10",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "kw7hhr"
+            ],
+            "children": [
+                "RstKcF"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "t",
+                                    "#00a4db",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東西線",
+                                    "Tozai Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yurakucho Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "o",
+                                    "#ce1c64",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "都営大江戶線",
+                                    "Toei Oedo Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#fed304",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "中央線（各駅停車）",
+                                    "Chuo Line (Local)"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "RstKcF": {
+            "name": [
+                "東大前",
+                "Todaimae"
+            ],
+            "num": "11",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "tR9CVr"
+            ],
+            "children": [
+                "Mze0-_"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Mze0-_": {
+            "name": [
+                "本駒込",
+                "Hon-Komagome"
+            ],
+            "num": "12",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "RstKcF"
+            ],
+            "children": [
+                "1G4ZTW"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "1G4ZTW": {
+            "name": [
+                "駒込",
+                "Komagome"
+            ],
+            "num": "13",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Mze0-_"
+            ],
+            "children": [
+                "gehhWh"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#7bab4f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山手線",
+                                    "Yamanote Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "gehhWh": {
+            "name": [
+                "西ケ原",
+                "Nishigahara"
+            ],
+            "num": "14",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "1G4ZTW"
+            ],
+            "children": [
+                "jsvP5Y"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "jsvP5Y": {
+            "name": [
+                "王子",
+                "Oji"
+            ],
+            "num": "15",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "gehhWh"
+            ],
+            "children": [
+                "Sr3Jmn"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "jk",
+                                    "#00b2e6",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "京濱東北線",
+                                    "Keihin-Tohoku Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "sa",
+                                    "#d75b80",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "荒川線",
+                                    "Arakawa Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "王子站前",
+                            "Oji-Ekimae"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Sr3Jmn": {
+            "name": [
+                "王子神谷",
+                "Oji-Kamiya"
+            ],
+            "num": "16",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "jsvP5Y"
+            ],
+            "children": [
+                "UKOscu"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "UKOscu": {
+            "name": [
+                "志茂",
+                "Shimo"
+            ],
+            "num": "17",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Sr3Jmn"
+            ],
+            "children": [
+                "vRHUXa"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "vRHUXa": {
+            "name": [
+                "赤羽岩淵",
+                "Akabane-Iwabuchi"
+            ],
+            "num": "18",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "UKOscu"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "srr",
+                                    "#3564AF",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "埼玉高速鐵道線",
+                                    "Saitama-Kosoku-Tetsudo Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": false,
+        "isFlip": false
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "N",
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "direction_gz_x": 40,
+    "direction_gz_y": 79,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    },
+    "version": "5.14.12"
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Tokyo Metro on behalf of Charlis-Wong.
This should fix #801

**Review links**
[tyometro/N.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F77abd59dc5679844016ab82e37c3ea117c7eb3ba%2Fpublic%2Fresources%2Ftemplates%2Ftyometro%2FN.json)