### PR TITLE
Resources: New templates of East Japan Railway

### DIFF
--- a/public/resources/templates/JREAST/00config.json
+++ b/public/resources/templates/JREAST/00config.json
@@ -48,5 +48,15 @@
             "ja": "東金線"
         },
         "uploadBy": "Charlis-Wong"
+    },
+    {
+        "filename": "Tazawako Line",
+        "name": {
+            "en": "Tazawako Line",
+            "zh-Hans": "田泽湖线",
+            "zh-Hant": "田澤湖線",
+            "ja": "田沢湖線"
+        },
+        "uploadBy": "Charlis-Wong"
     }
 ]

--- a/public/resources/templates/JREAST/Tazawako Line.json
+++ b/public/resources/templates/JREAST/Tazawako Line.json
@@ -1,0 +1,634 @@
+{
+    "svgWidth": {
+        "destination": 2000,
+        "runin": 2000,
+        "railmap": 3000,
+        "indoor": 3500
+    },
+    "svg_height": 450,
+    "style": "mtr",
+    "y_pc": 50,
+    "padding": 10,
+    "branchSpacingPct": 33,
+    "direction": "l",
+    "platform_num": "1",
+    "theme": [
+        "other",
+        "other",
+        "#835ba0",
+        "#fff"
+    ],
+    "line_name": [
+        "田沢湖線",
+        "Tazawako Line"
+    ],
+    "current_stn_idx": "y6yuid",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "UQYc4l"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "UQYc4l": {
+            "name": [
+                "大曲",
+                "Ōmagari"
+            ],
+            "num": "01",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "I0NkwT"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#e7661f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "奥羽本线",
+                                    "Ōu Mainline"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "I0NkwT": {
+            "name": [
+                "北大曲",
+                "Kita-Ōmagari"
+            ],
+            "num": "02",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "UQYc4l"
+            ],
+            "children": [
+                "DUQ50_"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "lineend": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "y6yuid"
+            ],
+            "children": [],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "DUQ50_": {
+            "name": [
+                "羽後四ツ屋\t",
+                "Ugo-Yotsuya"
+            ],
+            "num": "03",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "I0NkwT"
+            ],
+            "children": [
+                "RmjafX"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "RmjafX": {
+            "name": [
+                "鑓見内\t",
+                "Yariminai"
+            ],
+            "num": "04",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "DUQ50_"
+            ],
+            "children": [
+                "N0ApsK"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "N0ApsK": {
+            "name": [
+                "羽後長野\t",
+                "Ugo-Nagano"
+            ],
+            "num": "05",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "RmjafX"
+            ],
+            "children": [
+                "g3-iUG"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "g3-iUG": {
+            "name": [
+                "鶯野\t",
+                "Uguisuno"
+            ],
+            "num": "06",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "N0ApsK"
+            ],
+            "children": [
+                "uOWeoJ"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "uOWeoJ": {
+            "name": [
+                "角館\t",
+                "Kakunodate"
+            ],
+            "num": "07",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "g3-iUG"
+            ],
+            "children": [
+                "netnsb"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#fb0006",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "秋田内陸線",
+                                    "Akita Nairiku Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "netnsb": {
+            "name": [
+                "生田",
+                "Shōden"
+            ],
+            "num": "08",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "uOWeoJ"
+            ],
+            "children": [
+                "N2VYbL"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "N2VYbL": {
+            "name": [
+                "神代",
+                "Jindai"
+            ],
+            "num": "09",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "netnsb"
+            ],
+            "children": [
+                "Ie7rPM"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "Ie7rPM": {
+            "name": [
+                "刺巻",
+                "Sashimaki"
+            ],
+            "num": "10",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "N2VYbL"
+            ],
+            "children": [
+                "AKrrag"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "AKrrag": {
+            "name": [
+                "田沢湖\t",
+                "Tazawako"
+            ],
+            "num": "11",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Ie7rPM"
+            ],
+            "children": [
+                "9sinCB"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 200
+        },
+        "9sinCB": {
+            "name": [
+                "赤渕",
+                "Akabuchi"
+            ],
+            "num": "12",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "AKrrag"
+            ],
+            "children": [
+                "0o6peh"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "0o6peh": {
+            "name": [
+                "春木場\t",
+                "Harukiba"
+            ],
+            "num": "13",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "9sinCB"
+            ],
+            "children": [
+                "4gXz2-"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "4gXz2-": {
+            "name": [
+                "雫石\t",
+                "Shizukuishi"
+            ],
+            "num": "14",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "0o6peh"
+            ],
+            "children": [
+                "yoY3_V"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "yoY3_V": {
+            "name": [
+                "小岩井\t",
+                "Koiwai"
+            ],
+            "num": "15",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "4gXz2-"
+            ],
+            "children": [
+                "1iEbbM"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "1iEbbM": {
+            "name": [
+                "大釜\t",
+                "Ōkama"
+            ],
+            "num": "16",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "yoY3_V"
+            ],
+            "children": [
+                "yDxBZU"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "yDxBZU": {
+            "name": [
+                "前潟",
+                "Maegata"
+            ],
+            "num": "17",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "1iEbbM"
+            ],
+            "children": [
+                "y6yuid"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "y6yuid": {
+            "name": [
+                "盛岡\t",
+                "Morioka"
+            ],
+            "num": "18",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "yDxBZU"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#33a85e",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東北本線",
+                                    "Tōhoku Line "
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#bf6619",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "山田線",
+                                    "Yamada Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#0831aa",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "いわて銀河鉄道線",
+                                    "Iwate Galaxy Railway Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 300
+        }
+    },
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": true
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "--",
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "direction_gz_x": 40,
+    "direction_gz_y": 70,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    },
+    "version": "5.14.12"
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of East Japan Railway on behalf of Charlis-Wong.
This should fix #884

**Review links**
[JREAST/Tazawako Line.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F5c0258561ba3265fb4244a1ca6427314506f0076%2Fpublic%2Fresources%2Ftemplates%2FJREAST%2FTazawako%20Line.json)