### PR TITLE
Resources: New templates of East Japan Railway

### DIFF
--- a/public/resources/templates/JREAST/00config.json
+++ b/public/resources/templates/JREAST/00config.json
@@ -48,5 +48,15 @@
             "ja": "東金線"
         },
         "uploadBy": "Charlis-Wong"
+    },
+    {
+        "filename": "szl",
+        "name": {
+            "en": "Senzan Line",
+            "zh-Hans": "仙山线",
+            "zh-Hant": "仙山線",
+            "ja": "仙山線"
+        },
+        "uploadBy": "liberecolynn"
     }
 ]

--- a/public/resources/templates/JREAST/szl.json
+++ b/public/resources/templates/JREAST/szl.json
@@ -1,0 +1,646 @@
+{
+    "svgWidth": {
+        "destination": 2000,
+        "runin": 2000,
+        "railmap": 4000,
+        "indoor": 4000
+    },
+    "svg_height": 500,
+    "style": "shmetro",
+    "y_pc": 50,
+    "padding": 10,
+    "branchSpacingPct": 33,
+    "direction": "l",
+    "platform_num": "1",
+    "theme": [
+        "other",
+        "other",
+        "#68db08",
+        "#fff"
+    ],
+    "line_name": [
+        "仙山線",
+        "Senzan Line"
+    ],
+    "current_stn_idx": "hjZiIZ",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "b0L0sa"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "b0L0sa": {
+            "name": [
+                "仙台",
+                "Sendai"
+            ],
+            "num": "01",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "LM_8c1"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#33a85e",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東北本線",
+                                    "Tōhoku Mainline"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#1498e9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "仙石線",
+                                    "Senseki Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#128765",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "仙台地下鉄南北線",
+                                    "Sendai Subway Namboku Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#16a8de",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "仙台地下鉄東西線",
+                                    "Sendai Subway Tōzai Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 450
+        },
+        "LM_8c1": {
+            "name": [
+                "東照宮\t",
+                "Tōshōgū"
+            ],
+            "num": "02",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "b0L0sa"
+            ],
+            "children": [
+                "cenb5Y"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "hjZiIZ"
+            ],
+            "children": [],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "cenb5Y": {
+            "name": [
+                "北仙台\t",
+                "Kita-Sendai"
+            ],
+            "num": "03",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "LM_8c1"
+            ],
+            "children": [
+                "Bii2K0"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#128765",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "仙台地下鉄南北線",
+                                    "Sendai Subway Namboku Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Bii2K0": {
+            "name": [
+                "北山\t",
+                "Kitayama"
+            ],
+            "num": "04",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "cenb5Y"
+            ],
+            "children": [
+                "K8QvIX"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "K8QvIX": {
+            "name": [
+                "東北福祉大前\t",
+                "Tōhoku Fukushi-dai-mae"
+            ],
+            "num": "05",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Bii2K0"
+            ],
+            "children": [
+                "qziBmZ"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "qziBmZ": {
+            "name": [
+                "国見\t",
+                "Kunimi"
+            ],
+            "num": "06",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "K8QvIX"
+            ],
+            "children": [
+                "XXYm2b"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "XXYm2b": {
+            "name": [
+                "葛岡\t",
+                "Kuzuoka"
+            ],
+            "num": "07",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "qziBmZ"
+            ],
+            "children": [
+                "x9OMhr"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "x9OMhr": {
+            "name": [
+                "陸前落合",
+                "Rikuzen-Ochiai"
+            ],
+            "num": "08",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "XXYm2b"
+            ],
+            "children": [
+                "OwvwgT"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "OwvwgT": {
+            "name": [
+                "愛子\t",
+                "Ayashi"
+            ],
+            "num": "09",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "x9OMhr"
+            ],
+            "children": [
+                "zgRs2W"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "zgRs2W": {
+            "name": [
+                "陸前白沢\t",
+                "Rikuzen-Shirasawa"
+            ],
+            "num": "10",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "OwvwgT"
+            ],
+            "children": [
+                "SZlErE"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "SZlErE": {
+            "name": [
+                "熊ケ根\t",
+                "Kumagane"
+            ],
+            "num": "11",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "zgRs2W"
+            ],
+            "children": [
+                "3zIdVm"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "3zIdVm": {
+            "name": [
+                "作並\t",
+                "Sakunami"
+            ],
+            "num": "12",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "SZlErE"
+            ],
+            "children": [
+                "eqOEtL"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "eqOEtL": {
+            "name": [
+                "奥新川\t",
+                "Oku-Nikkawa"
+            ],
+            "num": "13",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "3zIdVm"
+            ],
+            "children": [
+                "92fKrv"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "92fKrv": {
+            "name": [
+                "面白山高原\t",
+                "Omoshiroyama-Kōgen"
+            ],
+            "num": "14",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "eqOEtL"
+            ],
+            "children": [
+                "dfArMj"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "dfArMj": {
+            "name": [
+                "山寺\t",
+                "Yamadera"
+            ],
+            "num": "15",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "92fKrv"
+            ],
+            "children": [
+                "f2y23S"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "f2y23S": {
+            "name": [
+                "高瀬\t",
+                "Takase"
+            ],
+            "num": "16",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "dfArMj"
+            ],
+            "children": [
+                "C3p00n"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "C3p00n": {
+            "name": [
+                "楯山\t",
+                "Tateyama"
+            ],
+            "num": "17",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "f2y23S"
+            ],
+            "children": [
+                "hjZiIZ"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "hjZiIZ": {
+            "name": [
+                "羽前千歳\t",
+                "Uzen-Chitose"
+            ],
+            "num": "18",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "C3p00n"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#e7661f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "奥羽本線",
+                                    "Ōu Mainline"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": true
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "--",
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "direction_gz_x": 40,
+    "direction_gz_y": 70,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    },
+    "version": "5.14.11.#576-Configure-nameDirection-in-indoor-stations-of-shmetro.7657b7d"
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of East Japan Railway on behalf of liberecolynn.
This should fix #894

**Review links**
[JREAST/szl.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F9eb4f51d60796d2974b77c7a83fc0c8f1b4cffbd%2Fpublic%2Fresources%2Ftemplates%2FJREAST%2Fszl.json)