### PR TITLE
Resources: New templates of MTR

### DIFF
--- a/public/resources/templates/mtr/00config.json
+++ b/public/resources/templates/mtr/00config.json
@@ -107,5 +107,14 @@
             "zh-Hant": "輕鐵505綫"
         },
         "uploadBy": "cartop-114514"
+    },
+    {
+        "filename": "LRT705",
+        "name": {
+            "en": "Light Rail Route 705",
+            "zh-Hans": "轻铁705线",
+            "zh-Hant": "輕鐵705綫"
+        },
+        "uploadBy": "KuKingTinKimi"
     }
 ]

--- a/public/resources/templates/mtr/LRT705.json
+++ b/public/resources/templates/mtr/LRT705.json
@@ -1,0 +1,1072 @@
+{
+    "svgWidth": {
+        "destination": 1200,
+        "runin": 1200,
+        "railmap": 2000,
+        "indoor": 1200
+    },
+    "svg_height": 300,
+    "style": "mtr",
+    "y_pc": 50,
+    "padding": 4,
+    "branchSpacingPct": 33,
+    "direction": "r",
+    "platform_num": "1",
+    "theme": [
+        "hongkong",
+        "lrl705",
+        "#64C542",
+        "#fff"
+    ],
+    "line_name": [
+        "輕鐵705綫",
+        "Light Rail Route 705"
+    ],
+    "current_stn_idx": "AhUSnq",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "AhUSnq"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "AhUSnq": {
+            "name": [
+                "天水圍",
+                "Tin Shui Wai"
+            ],
+            "num": "01",
+            "services": [
+                "local",
+                "express",
+                "direct"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "YhSM7l"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl751",
+                                    "#F47216",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751線",
+                                    "Light Rail Route 751"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#000000",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751P線",
+                                    "Light Rail Route 751P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "mol",
+                                    "#9A3820",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "屯馬綫",
+                                    "Tuen Ma Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "YhSM7l": {
+            "name": [
+                "天慈",
+                "Tin Tsz"
+            ],
+            "num": "02",
+            "services": [
+                "local",
+                "direct"
+            ],
+            "parents": [
+                "AhUSnq"
+            ],
+            "children": [
+                "IVdTb3"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl751",
+                                    "#F47216",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751線",
+                                    "Light Rail Route 751"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#000000",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751P線",
+                                    "Light Rail Route 751P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    },
+                    {},
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "C3p89_"
+            ],
+            "children": [],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "eT-o3v": {
+            "name": [
+                "頌富",
+                "Chung Fu"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "UiJwg1"
+            ],
+            "children": [
+                "nLZQ5Z"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl751",
+                                    "#F47216",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751線",
+                                    "Light Rail Route 751"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#000000",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751P線",
+                                    "Light Rail Route 751P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl761",
+                                    "#672290",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵761P線",
+                                    "Light Rail Route 761P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "UiJwg1": {
+            "name": [
+                "天富",
+                "Tin Fu"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "kfwrjR"
+            ],
+            "children": [
+                "eT-o3v"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl751",
+                                    "#F47216",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751線",
+                                    "Light Rail Route 751"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#000000",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751P線",
+                                    "Light Rail Route 751P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl761",
+                                    "#672290",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵761P線",
+                                    "Light Rail Route 761P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "kfwrjR": {
+            "name": [
+                "天逸",
+                "Tin Yat"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ot6Kba"
+            ],
+            "children": [
+                "UiJwg1"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl751",
+                                    "#F47216",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751線",
+                                    "Light Rail Route 751"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#000000",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751P線",
+                                    "Light Rail Route 751P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl761",
+                                    "#672290",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵761P線",
+                                    "Light Rail Route 761P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "ot6Kba": {
+            "name": [
+                "天恒",
+                "Tin Hang"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "I_Q4C4"
+            ],
+            "children": [
+                "kfwrjR"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "I_Q4C4": {
+            "name": [
+                "濕地公園",
+                "Wetland Park"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Prsg1Z"
+            ],
+            "children": [
+                "ot6Kba"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Prsg1Z": {
+            "name": [
+                "天秀",
+                "Tin Sau"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "QAztOm"
+            ],
+            "children": [
+                "I_Q4C4"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "QAztOm": {
+            "name": [
+                "天悅",
+                "Tin Yuet"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "seHdPp"
+            ],
+            "children": [
+                "Prsg1Z"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "seHdPp": {
+            "name": [
+                "天榮",
+                "Tin Wing"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "9HibE-"
+            ],
+            "children": [
+                "QAztOm"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl751",
+                                    "#F47216",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751線",
+                                    "Light Rail Route 751"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#000000",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751P線",
+                                    "Light Rail Route 751"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "9HibE-": {
+            "name": [
+                "銀座",
+                "Ginza"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "IVdTb3"
+            ],
+            "children": [
+                "seHdPp"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl751",
+                                    "#F47216",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751線",
+                                    "Light Rail Route 751"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#000000",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751P線",
+                                    "Light Rail Route 751P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "IVdTb3": {
+            "name": [
+                "天湖",
+                "Tin Wu"
+            ],
+            "num": "00",
+            "services": [
+                "local",
+                "direct"
+            ],
+            "parents": [
+                "YhSM7l"
+            ],
+            "children": [
+                "9HibE-"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl751",
+                                    "#F47216",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751線",
+                                    "Light Rail Route 751"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#000000",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751P線",
+                                    "Light Rail Route 751P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "l5KFYY": {
+            "name": [
+                "天耀\t",
+                "Tin Yiu"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "hboekm"
+            ],
+            "children": [
+                "C3p89_"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl761",
+                                    "#672290",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵761P線",
+                                    "Light Rail Route 761P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "hboekm": {
+            "name": [
+                "樂湖",
+                "Locwood"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "nLZQ5Z"
+            ],
+            "children": [
+                "l5KFYY"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl761",
+                                    "#672290",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵761P線",
+                                    "Light Rail Route 761P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "nLZQ5Z": {
+            "name": [
+                "天瑞",
+                "Tin Shui"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "eT-o3v"
+            ],
+            "children": [
+                "hboekm"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl761",
+                                    "#672290",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵761P線",
+                                    "Light Rail Route 761P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "C3p89_": {
+            "name": [
+                "天水圍",
+                "Tin Shui Wai"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "l5KFYY"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl751",
+                                    "#F47216",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751線",
+                                    "Light Rail Route 751"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "other",
+                                    "other",
+                                    "#000000",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵751P線",
+                                    "Light Rail Route 751P"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "mol",
+                                    "#9A3820",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "屯馬綫",
+                                    "Tuen Ma Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "hongkong",
+                                    "lrl706",
+                                    "#B365B9",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "輕鐵706線",
+                                    "Light Rail Route 706"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": true
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "1",
+    "spanLineNum": true,
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "direction_gz_x": 40,
+    "direction_gz_y": 70,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    },
+    "version": "5.16.3"
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of MTR on behalf of KuKingTinKimi.
This should fix #994

**Review links**
[mtr/LRT705.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F4e893c84e4fffaf5b222c748131ac1a1867c15f0%2Fpublic%2Fresources%2Ftemplates%2Fmtr%2FLRT705.json)