### PR TITLE
Resources: New templates of Tokyo Metro

### DIFF
--- a/public/resources/templates/tyometro/00config.json
+++ b/public/resources/templates/tyometro/00config.json
@@ -44,7 +44,7 @@
         "name": {
             "en": "Namboku Line",
             "zh-Hans": "南北线",
-            "zh-Hant": "南北",
+            "zh-Hant": "南北線",
             "ja": "南北線"
         },
         "uploadBy": "Charlis-Wong"


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Tokyo Metro on behalf of Charlis-Wong.
This should fix #1011

**Review links**
[tyometro/N.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F292f78209dbc3b12d297064459bdd1d9890f054b%2Fpublic%2Fresources%2Ftemplates%2Ftyometro%2FN.json)