### PR TITLE
Resources: New templates of MTR

### DIFF
--- a/public/resources/templates/mtr/LRT705.json
+++ b/public/resources/templates/mtr/LRT705.json
@@ -19,8 +19,8 @@
         "#fff"
     ],
     "line_name": [
-        "輕鐵705綫",
-        "Light Rail Route 705"
+        "輕鐵505綫",
+        "Light Rail Route 505"
     ],
     "current_stn_idx": "AhUSnq",
     "stn_list": {
@@ -1068,5 +1068,5 @@
         "left_and_right_factor": 1,
         "bottom_factor": 1
     },
-    "version": "5.16.3"
+    "version": "5.15.3"
 }


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of MTR on behalf of KuKingTinKimi.
This should fix #969

**Review links**
[mtr/LRT705.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F7e8a640be89135263ff6c5b03103743dd3855bc9%2Fpublic%2Fresources%2Ftemplates%2Fmtr%2FLRT705.json)