### PR TITLE
Resources: New templates of Shanghai Metro Line 13

### DIFF
--- a/public/resources/templates/shmetro/00config.json
+++ b/public/resources/templates/shmetro/00config.json
@@ -73,9 +73,9 @@
         "filename": "sh7",
         "name": {
             "en": "Line 7",
-            "ko": "7호선",
             "zh-Hans": "7号线",
-            "zh-Hant": "7號線"
+            "zh-Hant": "7號線",
+            "ko": "7호선"
         },
         "uploadBy": "Thomastzc"
     },

--- a/public/resources/templates/shmetro/sh7.json
+++ b/public/resources/templates/shmetro/sh7.json
@@ -412,7 +412,7 @@
                                 ],
                                 "name": [
                                     "13号线",
-                                    "Line"
+                                    "Line 13"
                                 ]
                             }
                         ]
@@ -1197,5 +1197,5 @@
         "bottom_factor": 1
     },
     "branchSpacingPct": 34,
-    "version": "5.14.12"
+    "version": "5.16.4"
 }


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Shanghai Metro Line 13 on behalf of 816R.
This should fix #1037

**Review links**
[shmetro/sh7.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2F652886c482bb32c3155a78aab8b96c08064a65c6%2Fpublic%2Fresources%2Ftemplates%2Fshmetro%2Fsh7.json)