### PR TITLE
Resources: New templates of Tokyo Metro

### DIFF
--- a/public/resources/templates/tyometro/00config.json
+++ b/public/resources/templates/tyometro/00config.json
@@ -48,5 +48,15 @@
             "ja": "南北線"
         },
         "uploadBy": "Charlis-Wong"
+    },
+    {
+        "filename": "h",
+        "name": {
+            "en": "Hibiya Line",
+            "zh-Hans": "日比谷线",
+            "zh-Hant": "日比谷線",
+            "ja": "日比谷線"
+        },
+        "uploadBy": "Xebalu"
     }
 ]

--- a/public/resources/templates/tyometro/h.json
+++ b/public/resources/templates/tyometro/h.json
@@ -1,0 +1,1019 @@
+{
+    "svgWidth": {
+        "destination": 1500,
+        "runin": 2500,
+        "railmap": 5000,
+        "indoor": 10000
+    },
+    "svg_height": 700,
+    "style": "mtr",
+    "y_pc": 51,
+    "padding": 10,
+    "branchSpacingPct": 33,
+    "direction": "r",
+    "platform_num": "1",
+    "theme": [
+        "tokyo",
+        "h",
+        "#c7beb3",
+        "#fff"
+    ],
+    "line_name": [
+        "日比谷線",
+        "Hibiya Line"
+    ],
+    "current_stn_idx": "KgVpo3",
+    "stn_list": {
+        "linestart": {
+            "name": [
+                "RIGHT END",
+                "RIGHT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [],
+            "children": [
+                "KgVpo3"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "1aaMf3": {
+            "name": [
+                "上野",
+                "Ueno"
+            ],
+            "num": "20",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "bbzyAf"
+            ],
+            "children": [
+                "4go8c4"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#f9a328",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "bbzyAf": {
+            "name": [
+                "仲御徒町",
+                "Naka-Okachimachi"
+            ],
+            "num": "19",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ZPQMw7"
+            ],
+            "children": [
+                "1aaMf3"
+            ],
+            "transfer": {
+                "groups": [
+                    {},
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#f9a328",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "上野広小路",
+                            "Ueno-Hirokoji"
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "e",
+                                    "#ce1c64",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大江戶線",
+                                    "Oedo Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "上野御徒町",
+                            "Ueno-Okachimachi"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "lineend": {
+            "name": [
+                "LEFT END",
+                "LEFT END"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "XgyR7B"
+            ],
+            "children": [],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "ZPQMw7": {
+            "name": [
+                "秋葉原",
+                "Akihabara"
+            ],
+            "num": "18",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "9hM_EB"
+            ],
+            "children": [
+                "bbzyAf"
+            ],
+            "transfer": {
+                "groups": [
+                    {},
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "s",
+                                    "#abba41",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "新宿線",
+                                    "Shinjuku Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "岩本町",
+                            "Iwamotocho"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 500
+        },
+        "9hM_EB": {
+            "name": [
+                "小伝馬町",
+                "Kodemmacho"
+            ],
+            "num": "17",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "5rpLUm"
+            ],
+            "children": [
+                "ZPQMw7"
+            ],
+            "transfer": {
+                "groups": [
+                    {},
+                    {},
+                    {
+                        "name": [
+                            "",
+                            ""
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "5rpLUm": {
+            "name": [
+                "人形町",
+                "Ningyocho"
+            ],
+            "num": "16",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "ivu4t7"
+            ],
+            "children": [
+                "9hM_EB"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "a",
+                                    "#dd4231",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "淺草線",
+                                    "Asakusa Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "z",
+                                    "#8c7dba",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "半藏門線",
+                                    "Hanzomon Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "水天宮前",
+                            "Suitingumae"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 400
+        },
+        "ivu4t7": {
+            "name": [
+                "茅場町",
+                "Kayabacho"
+            ],
+            "num": "15",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "gXH7Tf"
+            ],
+            "children": [
+                "5rpLUm"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "t",
+                                    "#00a4db",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "東西線",
+                                    "Tozai Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "gXH7Tf": {
+            "name": [
+                "八丁堀",
+                "Hatchobori"
+            ],
+            "num": "14",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "-UTlSt"
+            ],
+            "children": [
+                "ivu4t7"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "-UTlSt": {
+            "name": [
+                "築地",
+                "Tsukiji"
+            ],
+            "num": "12",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "6FzOjv"
+            ],
+            "children": [
+                "gXH7Tf"
+            ],
+            "transfer": {
+                "groups": [
+                    {},
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yūrakuchō Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "新富町",
+                            "Shintomicho"
+                        ]
+                    },
+                    {
+                        "name": [
+                            "",
+                            ""
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 650
+        },
+        "6FzOjv": {
+            "name": [
+                "東銀座",
+                "Higashi-ginza"
+            ],
+            "num": "11",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "d6KGkJ"
+            ],
+            "children": [
+                "-UTlSt"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "a",
+                                    "#dd4231",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "淺草線",
+                                    "Asakusa Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "d6KGkJ": {
+            "name": [
+                "銀座",
+                "Ginza"
+            ],
+            "num": "10",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "kw-1rh"
+            ],
+            "children": [
+                "6FzOjv"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#f9a328",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸之內線",
+                                    "Marunouchi Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "name": [
+                            "",
+                            ""
+                        ]
+                    },
+                    {
+                        "name": [
+                            "東京",
+                            "Tokyo"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "kw-1rh": {
+            "name": [
+                "日比谷",
+                "Hibiya"
+            ],
+            "num": "09",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "E7S5Fy"
+            ],
+            "children": [
+                "d6KGkJ"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "i",
+                                    "#0068a5",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "三田線",
+                                    "Mita Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "c",
+                                    "#1bb267",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "千代田線",
+                                    "Chiyoda Line"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "y",
+                                    "#d1a662",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "有楽町線",
+                                    "Yūrakuchō Line"
+                                ]
+                            }
+                        ],
+                        "name": [
+                            "有楽町",
+                            "Yurakocho"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": false
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 450
+        },
+        "E7S5Fy": {
+            "name": [
+                "霞ケ関",
+                "Kusumigaseki"
+            ],
+            "num": "08",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Q_gf80"
+            ],
+            "children": [
+                "kw-1rh"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "c",
+                                    "#1bb267",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "千代田線",
+                                    "Chiyoda Line"
+                                ]
+                            },
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "m",
+                                    "#d92c2f",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "丸之內線",
+                                    "Marunouchi Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Q_gf80": {
+            "name": [
+                "虎ノ門ヒルズ",
+                "Toranomon Hills"
+            ],
+            "num": "06",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "vzyjcn"
+            ],
+            "children": [
+                "E7S5Fy"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "g",
+                                    "#f9a328",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "銀座線",
+                                    "Ginza Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "vzyjcn": {
+            "name": [
+                "神谷町",
+                "Kamiyacho"
+            ],
+            "num": "05",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "OlPWQN"
+            ],
+            "children": [
+                "Q_gf80"
+            ],
+            "transfer": {
+                "groups": [
+                    {},
+                    {
+                        "name": [
+                            "六本木",
+                            "Roppongi"
+                        ]
+                    },
+                    {
+                        "name": [
+                            "六本木",
+                            "Roppongi"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "OlPWQN": {
+            "name": [
+                "六本木",
+                "Roppongi"
+            ],
+            "num": "04",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "gq8Lgb"
+            ],
+            "children": [
+                "vzyjcn"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "e",
+                                    "#ce1c64",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "大江戶線",
+                                    "Oedo Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "gq8Lgb": {
+            "name": [
+                "広尾",
+                "Hiro-o"
+            ],
+            "num": "03",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "UW8MzO"
+            ],
+            "children": [
+                "OlPWQN"
+            ],
+            "transfer": {
+                "groups": [
+                    {},
+                    {},
+                    {
+                        "name": [
+                            "原宿",
+                            "Harajuku"
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "UW8MzO": {
+            "name": [
+                "惠比寿",
+                "Ebisu"
+            ],
+            "num": "02",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "KgVpo3"
+            ],
+            "children": [
+                "gq8Lgb"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "KgVpo3": {
+            "name": [
+                "中目黑",
+                "Maka-Meguro"
+            ],
+            "num": "01",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "linestart"
+            ],
+            "children": [
+                "UW8MzO"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "4go8c4": {
+            "name": [
+                "入谷",
+                "Iriya"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "1aaMf3"
+            ],
+            "children": [
+                "7-TuVX"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "7-TuVX": {
+            "name": [
+                "三ノ輪",
+                "Minowa"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "4go8c4"
+            ],
+            "children": [
+                "Ll6Iy6"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "Ll6Iy6": {
+            "name": [
+                "南千住",
+                "Minami-Sanju"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "7-TuVX"
+            ],
+            "children": [
+                "XgyR7B"
+            ],
+            "transfer": {
+                "groups": [
+                    {}
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        },
+        "XgyR7B": {
+            "name": [
+                "北千住",
+                "Kita-Sanju"
+            ],
+            "num": "00",
+            "services": [
+                "local"
+            ],
+            "parents": [
+                "Ll6Iy6"
+            ],
+            "children": [
+                "lineend"
+            ],
+            "transfer": {
+                "groups": [
+                    {
+                        "lines": [
+                            {
+                                "theme": [
+                                    "tokyo",
+                                    "c",
+                                    "#1bb267",
+                                    "#fff"
+                                ],
+                                "name": [
+                                    "千代田線",
+                                    "Chiyoda Line"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "tick_direc": "r",
+                "paid_area": true
+            },
+            "loop_pivot": false,
+            "one_line": true,
+            "int_padding": 355
+        }
+    },
+    "namePosMTR": {
+        "isStagger": true,
+        "isFlip": true
+    },
+    "customiseMTRDest": {
+        "isLegacy": false,
+        "terminal": false
+    },
+    "line_num": "C",
+    "psd_num": "1",
+    "info_panel_type": "gz1",
+    "direction_gz_x": 34,
+    "direction_gz_y": 76,
+    "coline": {},
+    "loop": false,
+    "loop_info": {
+        "bank": true,
+        "left_and_right_factor": 1,
+        "bottom_factor": 1
+    },
+    "version": "5.15.3"
+}


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New templates of Tokyo Metro on behalf of Xebalu.
This should fix #1044

**Review links**
[tyometro/h.json](https://uat-railmapgen.github.io/rmg/#/?external=https%3A%2F%2Fraw.githubusercontent.com%2Frailmapgen%2Frmg-templates%2Fca670470ec87ca879685b7ce5a9c801101ca0408%2Fpublic%2Fresources%2Ftemplates%2Ftyometro%2Fh.json)